### PR TITLE
Fix toast listener effect

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,8 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // The listener only needs to be registered once on mount
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent toast hook from re-registering listeners on each state update

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841c55e29a48321ab4caa28f97c617b