### PR TITLE
Fix email hash logic

### DIFF
--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -233,7 +233,7 @@ function hashEmail(email: string): string {
   for (let i = 0; i < email.length; i++) {
     const char = email.charCodeAt(i)
     hash = (hash << 5) - hash + char
-    hash = hash & hash // Convert to 32bit integer
+    hash = hash & 0xffffffff // Convert to 32bit integer
   }
   return hash.toString(16)
 }

--- a/utils/skool-pixel.ts
+++ b/utils/skool-pixel.ts
@@ -32,7 +32,7 @@ function hashEmail(email: string): string {
   for (let i = 0; i < email.length; i++) {
     const char = email.charCodeAt(i)
     hash = (hash << 5) - hash + char
-    hash = hash & hash // Convert to 32bit integer
+    hash = hash & 0xffffffff // Convert to 32bit integer
   }
   return hash.toString(16)
 }


### PR DESCRIPTION
## Summary
- ensure email hashing uses a 32-bit mask in analytics
- apply same fix to skool-pixel utilities

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ca6c6ccc83219258e648a33aa669