### PR TITLE
Optimize ClientShowcase with IntersectionObserver

### DIFF
--- a/components/client-showcase.tsx
+++ b/components/client-showcase.tsx
@@ -233,12 +233,19 @@ export default function ClientShowcase() {
   const [clients, setClients] = useState<Client[]>([])
   const containerRef = useRef<HTMLDivElement>(null)
   const [isPaused, setIsPaused] = useState(false)
+  const isPausedRef = useRef(isPaused)
+  const prevPausedRef = useRef(isPaused)
   const [isLoaded, setIsLoaded] = useState(false)
   const [containerWidth, setContainerWidth] = useState(0)
   const [contentWidth, setContentWidth] = useState(0)
   const [animationDuration, setAnimationDuration] = useState(0)
   const [currentScrollPosition, setCurrentScrollPosition] = useState(0)
   const [imagesPreloaded, setImagesPreloaded] = useState(false)
+
+  // Keep a ref of the latest paused state for the IntersectionObserver
+  useEffect(() => {
+    isPausedRef.current = isPaused
+  }, [isPaused])
 
   useEffect(() => {
     // Ensure any previous Miguel entries (ID 23 or 24 or 27) are filtered out before shuffling
@@ -369,6 +376,28 @@ export default function ClientShowcase() {
   const handleTouchEnd = useCallback(() => {
     setIsPaused(false)
     trackClientShowcaseInteraction("touch_resume_scrolling")
+  }, [])
+
+  // Pause the animation when the showcase leaves the viewport
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setIsPaused(prevPausedRef.current)
+        } else {
+          prevPausedRef.current = isPausedRef.current
+          setIsPaused(true)
+        }
+      })
+    })
+
+    observer.observe(container)
+    return () => {
+      observer.disconnect()
+    }
   }, [])
 
   if (!isLoaded || clients.length === 0) {


### PR DESCRIPTION
## Summary
- pause ClientShowcase slideshow when it leaves the viewport

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68432e8fb590832195aadae544a6ea23