### PR TITLE
Add BlogPostLayout props

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -19,7 +19,17 @@ export default async function BlogPostPage({ params }: PageProps) {
   const { frontmatter } = await getPost(params.slug)
   const content = await renderPost(params.slug)
   return (
-    <BlogPostLayout frontmatter={frontmatter} slug={params.slug}>
+    <BlogPostLayout
+      slug={params.slug}
+      title={frontmatter.title}
+      description={frontmatter.description}
+      date={frontmatter.date}
+      category={frontmatter.category}
+      gradientClass={frontmatter.gradientClass}
+      image={frontmatter.image}
+      openGraph={frontmatter.openGraph}
+      canonical={frontmatter.canonical}
+    >
       {content}
     </BlogPostLayout>
   )

--- a/components/blog-post-layout.tsx
+++ b/components/blog-post-layout.tsx
@@ -8,16 +8,32 @@ import Breadcrumbs from "@/components/breadcrumbs"
 import ScrollProgressBar from "@/components/scroll-progress-bar"
 import { BlogPostSchema } from "@/components/schema-markup"
 import { cn } from "@/lib/utils"
-import type { BlogFrontmatter } from "@/lib/mdx"
 
 interface Props {
   children: React.ReactNode
-  frontmatter: BlogFrontmatter
   slug: string
+  title: string
+  description: string
+  date: string
+  category: string
+  gradientClass: string
+  image: string
+  openGraph?: any
+  canonical?: string
 }
 
-export default function BlogPostLayout({ children, frontmatter, slug }: Props) {
-  const { title, category, date, gradientClass } = frontmatter
+export default function BlogPostLayout({
+  children,
+  slug,
+  title,
+  description,
+  date,
+  category,
+  gradientClass,
+  image,
+  openGraph,
+  canonical,
+}: Props) {
   return (
     <div className="flex min-h-screen flex-col">
       <ScrollProgressBar />
@@ -59,12 +75,12 @@ export default function BlogPostLayout({ children, frontmatter, slug }: Props) {
       </div>
       <BlogPostSchema
         title={title}
-        description={frontmatter.description}
-        url={frontmatter.openGraph?.url || frontmatter.canonical || `https://prism.agency/blog/${slug}`}
-        imageUrl={`https://prism.agency${frontmatter.image}`}
-        datePublished={frontmatter.openGraph?.publishedTime || frontmatter.date}
-        dateModified={frontmatter.openGraph?.modifiedTime || frontmatter.date}
-        authorName={frontmatter.openGraph?.authors?.[0] || "prism"}
+        description={description}
+        url={openGraph?.url || canonical || `https://prism.agency/blog/${slug}`}
+        imageUrl={`https://prism.agency${image}`}
+        datePublished={openGraph?.publishedTime || date}
+        dateModified={openGraph?.modifiedTime || date}
+        authorName={openGraph?.authors?.[0] || "prism"}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- refine `BlogPostLayout` props to take post metadata directly
- update blog slug page to use new layout API

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68464a7c9a7c83219ff394ac5b58957a