### PR TITLE
Fix blog gradient backgrounds

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,7 @@ const config: Config = {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "*.{js,ts,jsx,tsx,mdx}",
+    "./content/**/*.{md,mdx}",
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- scan `content` directory for Tailwind classes so gradient backgrounds from blog posts are built correctly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684666ca5eec8321bd440c4b97db0381