### PR TITLE
Fix blog hero image

### DIFF
--- a/components/blog-post-layout.tsx
+++ b/components/blog-post-layout.tsx
@@ -50,8 +50,8 @@ export default function BlogPostLayout({
                     <CoreImage
                       src={image}
                       alt={title}
-                      width={Number(image.match(/width=(\d+)/)?.[1] || 1200)}
-                      height={Number(image.match(/height=(\d+)/)?.[1] || 630)}
+                      width={1200}
+                      height={630}
                       className="h-full w-full object-cover"
                       quality={90}
                       trackingId={`blogpost_${slug}`}


### PR DESCRIPTION
## Summary
- use `CoreImage` for blog post hero images
- fallback to gradient when there is no image

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847773d1eb48321bbbd42da80b83383