### PR TITLE
Refactor blog listing to server component

### DIFF
--- a/app/blog/BlogCTAButton.tsx
+++ b/app/blog/BlogCTAButton.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import Link from "next/link"
+import { ArrowRight } from "lucide-react"
+import { trackCTAClick } from "@/utils/analytics"
+
+export default function BlogCTAButton() {
+  return (
+    <Link href="/get-started">
+      <button
+        className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-medium text-white hover:bg-neutral-800 lowercase"
+        onClick={() => trackCTAClick("get started", "blog page")}
+      >
+        get started <ArrowRight className="ml-2 h-4 w-4" />
+      </button>
+    </Link>
+  )
+}

--- a/app/blog/BlogPage.tsx
+++ b/app/blog/BlogPage.tsx
@@ -1,11 +1,7 @@
-"use client"
-
-import Link from "next/link"
-import { ArrowRight } from "lucide-react"
 import Navbar from "@/components/navbar"
 import Footer from "@/components/footer"
-import PageViewTracker from "@/components/page-view-tracker"
-import { trackCTAClick } from "@/utils/analytics"
+import BlogPageTracker from "./BlogPageTracker"
+import BlogCTAButton from "./BlogCTAButton"
 import BlogPostCard from "@/components/blog-post-card"
 import type { BlogFrontmatter } from "@/lib/mdx"
 
@@ -21,7 +17,7 @@ export default function BlogPage({ posts }: { posts: BlogPost[] }) {
 
   return (
     <div className="flex min-h-screen flex-col">
-      <PageViewTracker title="Blog" />
+      <BlogPageTracker />
       <Navbar />
       <main className="flex-1">
         {/* Hero Section */}
@@ -75,14 +71,7 @@ export default function BlogPage({ posts }: { posts: BlogPost[] }) {
               <h2 className="text-2xl font-bold tracking-tighter lowercase sm:text-3xl">want to work with us?</h2>
               <p className="text-neutral-600 lowercase">let's discuss how we can help your business grow</p>
               <div className="pt-4">
-                <Link href="/get-started">
-                  <button
-                    className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-medium text-white hover:bg-neutral-800 lowercase"
-                    onClick={() => trackCTAClick("get started", "blog page")}
-                  >
-                    get started <ArrowRight className="ml-2 h-4 w-4" />
-                  </button>
-                </Link>
+                <BlogCTAButton />
               </div>
             </div>
           </div>

--- a/app/blog/BlogPageTracker.tsx
+++ b/app/blog/BlogPageTracker.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import PageViewTracker from "@/components/page-view-tracker"
+
+export default function BlogPageTracker() {
+  return <PageViewTracker title="Blog" />
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next"
-import BlogPage from "./client-page"
+import BlogPage from "./BlogPage"
 import { getAllPosts } from "@/lib/mdx"
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Summary
- convert the blog listing page to a server component
- track page views via a new `BlogPageTracker` client component
- add a client `BlogCTAButton` for analytics on the CTA
- update routing to use the new component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847773e756883219cba8051dbf59550