### PR TITLE
Add canonical link metadata for blog page

### DIFF
--- a/__tests__/blog-canonical.test.ts
+++ b/__tests__/blog-canonical.test.ts
@@ -1,0 +1,10 @@
+import fs from 'fs'
+import path from 'path'
+
+describe('blog page canonical', () => {
+  test('renders canonical link in built HTML', () => {
+    const htmlPath = path.join(process.cwd(), '.next/server/app/blog.html')
+    const html = fs.readFileSync(htmlPath, 'utf8')
+    expect(html).toContain('<link rel="canonical" href="https://prism.agency/blog"/>')
+  })
+})

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -5,6 +5,9 @@ import { getAllPosts } from "@/lib/mdx"
 export const metadata: Metadata = {
   title: "blog",
   description: "thoughts on design, development, and digital strategy from the prism team.",
+  alternates: {
+    canonical: "https://prism.agency/blog",
+  },
 }
 
 export default async function Blog() {


### PR DESCRIPTION
## Summary
- add canonical URL for blog page metadata
- ensure canonical `<link>` is output in build
- add test checking canonical `<link>` appears in built HTML

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6847774297b4832199686d82a47b3d8d