### PR TITLE
Fix repeated title in blog post

### DIFF
--- a/content/blog/founders-playbook-ai-era.mdx
+++ b/content/blog/founders-playbook-ai-era.mdx
@@ -27,7 +27,6 @@ twitter:
 canonical: "https://design-prism.com/blog/founders-playbook-ai-era"
 ---
 
-<h1 className="text-3xl font-bold mb-6">The Founder's Playbook for the AI Era: Timeless Wisdom from 27 Entrepreneurs</h1>
 <p className="text-lg font-medium mb-4">By Enzo Sison</p>
 
 <p className="text-lg leading-relaxed mb-6">


### PR DESCRIPTION
The `<h1>` tag containing the blog post title was removed from `content/blog/founders-playbook-ai-era.mdx`.

This change addresses a title duplication issue on the production web page. The title was already defined in the file's frontmatter, which is typically rendered by the blog layout component. Explicitly including an `<h1>` tag with the same title within the content caused it to appear twice.

Removing the redundant `<h1>` tag ensures the title is rendered only once, maintaining the intended display without affecting the author byline or subsequent content.