### PR TITLE
Remove sales guarantee text

### DIFF
--- a/app/designs/DesignsPageClient.tsx
+++ b/app/designs/DesignsPageClient.tsx
@@ -191,7 +191,6 @@ export default function DesignsPageClient() {
                       design my brand <ArrowRight className="ml-2 h-5 w-5" />
                     </Button>
                   </Link>
-                  <p className="text-xs text-neutral-500 mt-2 lowercase">2x sales in 90 days or don't pay</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- remove the "2x sales" guarantee caption from Designs page

## Testing
- `npm run build`
- `npm test` *(fails: cannot find `.next/server/app/blog/page.html`)*

------
https://chatgpt.com/codex/tasks/task_e_68558f7040d88321bc6d6f26922cd0da