### PR TITLE
Fix website name on card

### DIFF
--- a/app/websites/page.tsx
+++ b/app/websites/page.tsx
@@ -43,7 +43,7 @@ const websiteProjects = [
   },
   {
     id: "7",
-    title: "laguna beach dental",
+    title: "laguna beach dental arts",
     image: "/laguna-beach-dental-arts-mobile.png",
     url: "https://lagunabeachdentalarts.com",
     category: "healthcare",


### PR DESCRIPTION
## Summary
- update website card to show full name "laguna beach dental arts"

## Testing
- `npm run build`
- `npm test` *(fails: cannot find built blog page and server-only module)*

------
https://chatgpt.com/codex/tasks/task_e_685591f8bb5c8321bb75163399396359