### PR TITLE
Replace Exquisite case-study chart

### DIFF
--- a/app/case-studies/exquisite-dentistry/client-page.tsx
+++ b/app/case-studies/exquisite-dentistry/client-page.tsx
@@ -11,7 +11,7 @@ import { CaseStudySchema } from "@/components/schema-markup"
 import { trackCTAClick } from "@/utils/analytics"
 import { useState, useEffect } from "react"
 import SocialShare from "@/components/social-share"
-import { ExquisiteRankLiftChart } from "@/components/case-studies/exquisite-rank-lift-chart"
+import { ExquisitePillarKPIChart } from "@/components/case-studies/exquisite-pillar-kpi-chart"
 import { ExquisiteChannelShareChart } from "@/components/case-studies/exquisite-channel-share-chart"
 
 export default function ExquisiteDentistryCaseStudy() {
@@ -57,6 +57,17 @@ export default function ExquisiteDentistryCaseStudy() {
               <h1 className="text-3xl font-bold tracking-tighter sm:text-4xl">Aligning Digital Excellence with Luxury Care</h1>
               <p className="text-xl text-neutral-600">How Prism elevated Beverly Hills’ Exquisite Dentistry’s online presence to match their premium in-person experience.</p>
               <p className="text-neutral-500">Practice owner: <strong>Dr. Alexie Aguil</strong></p>
+              <p className="text-neutral-500">
+                Website:{" "}
+                <Link
+                  href="https://exquisitedentistryla.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-neutral-700 transition-colors"
+                >
+                  exquisitedentistryla.com
+                </Link>
+              </p>
             </div>
             <div className="mt-10 mb-6">
               <Image src="/exquisite-dentistry-consultation.png" alt="Exquisite Dentistry consultation" width={800} height={450} className="rounded-md w-full h-auto" priority />
@@ -148,9 +159,9 @@ export default function ExquisiteDentistryCaseStudy() {
                   </table>
                 </div>
                 <div className="mt-8">
-                  <ExquisiteRankLiftChart />
+                  <ExquisitePillarKPIChart />
                 </div>
-                <p className="text-sm text-neutral-500 italic mt-2">[Graphic: Interactive “Pillar-to-KPI” Sankey diagram mapping each tactic to the metric it moved]</p>
+                <p className="text-sm text-neutral-500 italic mt-2">Interactive diagram showing how each tactic contributed to key performance improvements</p>
               </section>
 
               {/* Transformation */}

--- a/components/case-studies/exquisite-pillar-kpi-chart.tsx
+++ b/components/case-studies/exquisite-pillar-kpi-chart.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { Sankey, ResponsiveContainer } from "recharts"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+
+const data = {
+  nodes: [
+    { name: "Bespoke Website Rebuild" },
+    { name: "UX First" },
+    { name: "Content Remix" },
+    { name: "Listing Clean-Up" },
+    { name: "Ad Campaigns" },
+    { name: "Systems Integration" },
+    { name: "AI-Ready Schema" },
+    { name: "Load Time" },
+    { name: "Mobile CTR" },
+    { name: "Pages/Session" },
+    { name: "Clicks" },
+    { name: "Local Pack" },
+    { name: "Leads" },
+    { name: "PMS" },
+    { name: "AI Search" },
+  ],
+  links: [
+    { source: 0, target: 7, value: 50 },
+    { source: 0, target: 8, value: 1 },
+    { source: 1, target: 9, value: 2 },
+    { source: 2, target: 10, value: 68 },
+    { source: 3, target: 11, value: 1 },
+    { source: 4, target: 12, value: 1 },
+    { source: 5, target: 13, value: 1 },
+    { source: 6, target: 14, value: 1 },
+  ],
+}
+
+const chartConfig = {
+  bespoke: { label: "Bespoke Website Rebuild", color: "hsl(var(--chart-1))" },
+  ux: { label: "UX First", color: "hsl(var(--chart-2))" },
+  content: { label: "Content Remix", color: "hsl(var(--chart-3))" },
+  listings: { label: "Listing Clean-Up", color: "hsl(var(--chart-4))" },
+  ads: { label: "Ad Campaigns", color: "hsl(var(--chart-5))" },
+  systems: { label: "Systems Integration", color: "hsl(var(--chart-6))" },
+  schema: { label: "AI-Ready Schema", color: "hsl(var(--chart-7))" },
+} satisfies ChartConfig
+
+export function ExquisitePillarKPIChart() {
+  return (
+    <ChartContainer config={chartConfig} className="w-full aspect-video md:h-[360px]">
+      <ResponsiveContainer width="100%" height="100%">
+        <Sankey
+          data={data}
+          nodePadding={30}
+          node={{ stroke: "hsl(var(--muted-foreground))", strokeWidth: 1 }}
+          link={{ stroke: "hsl(var(--chart-1))", strokeOpacity: 0.5 }}
+        >
+          <ChartTooltip
+            content={
+              <ChartTooltipContent className="rounded-lg shadow-lg bg-background/95 backdrop-blur-sm" />
+            }
+          />
+        </Sankey>
+      </ResponsiveContainer>
+    </ChartContainer>
+  )
+}
+


### PR DESCRIPTION
## Summary
- replace rank-lift chart with new Sankey diagram in Exquisite Dentistry case study
- add `ExquisitePillarKPIChart` component
- link to Exquisite Dentistry website
- remove default export from new chart component

## Testing
- `pnpm test` *(fails: jest not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a28cd280832181e54bcd488528c7