### PR TITLE
Remove KPI chart from Exquisite Dentistry case study

### DIFF
--- a/app/case-studies/exquisite-dentistry/client-page.tsx
+++ b/app/case-studies/exquisite-dentistry/client-page.tsx
@@ -147,10 +147,7 @@ export default function ExquisiteDentistryCaseStudy() {
                     </tbody>
                   </table>
                 </div>
-                <div className="mt-8">
-                  <ExquisitePillarKPIChart />
-                </div>
-                <p className="text-sm text-neutral-500 italic mt-2">Interactive diagram showing how each tactic contributed to key performance improvements</p>
+                {/* Removed interactive KPI chart per latest update */}
               </section>
 
               {/* Transformation */}


### PR DESCRIPTION
## Summary
- remove the interactive KPI chart from the "Prism’s Approach" section of the Exquisite Dentistry case study

## Testing
- `pnpm test` *(fails: ENOENT `.next/server/app/blog/page.html`)*

------
https://chatgpt.com/codex/tasks/task_e_6855a5dd2b1c83219a1eaa09cf897bd1