### PR TITLE
Optimize websites page images without binary files

### DIFF
--- a/app/websites/page.tsx
+++ b/app/websites/page.tsx
@@ -30,6 +30,8 @@ const websiteProjects = [
     url: "https://exquisiteveneersla.com/",
     category: "healthcare",
     description: "luxury cosmetic dentistry",
+    width: 1024,
+    height: 1536,
   },
   {
     id: "9",
@@ -38,6 +40,8 @@ const websiteProjects = [
     url: "https://belizekids.org",
     category: "nonprofit",
     description: "empowering children",
+    width: 1024,
+    height: 1536,
   },
   {
     id: "7",
@@ -46,6 +50,8 @@ const websiteProjects = [
     url: "https://lagunabeachdentalarts.com",
     category: "healthcare",
     description: "exceptional dental care",
+    width: 1024,
+    height: 1536,
   },
   {
     id: "3",
@@ -54,6 +60,8 @@ const websiteProjects = [
     url: "https://www.olympicbootworks.com",
     category: "retail",
     description: "performance solutions",
+    width: 1024,
+    height: 1536,
   },
   {
     id: "5",
@@ -62,6 +70,8 @@ const websiteProjects = [
     url: "https://www.chriswongdds.com",
     category: "healthcare",
     description: "modern dental care",
+    width: 1024,
+    height: 1536,
   },
   {
     id: "11",
@@ -70,6 +80,8 @@ const websiteProjects = [
     url: "https://www.coastperiodontics.com",
     category: "healthcare",
     description: "expert gum care",
+    width: 1024,
+    height: 1536,
   },
 ]
 

--- a/components/website-portfolio-grid.tsx
+++ b/components/website-portfolio-grid.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import Image from "next/image"
+import Image from "@/components/image"
 import { ArrowUpRight } from "lucide-react"
 import { trackCTAClick } from "@/utils/analytics"
 
@@ -12,6 +12,8 @@ interface WebsiteProject {
   url: string
   category: string
   description: string
+  width: number
+  height: number
 }
 
 interface WebsitePortfolioGridProps {
@@ -34,9 +36,11 @@ export default function WebsitePortfolioGrid({ projects }: WebsitePortfolioGridP
           <Image
             src={project.image}
             alt={project.title}
-            fill
-            className="object-cover object-center"
+            width={project.width}
+            height={project.height}
+            className="object-cover object-center w-full h-full"
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            showLoadingIndicator
           />
           
           {/* Gradient overlay for text readability */}


### PR DESCRIPTION
## Summary
- remove WebP images from repo to avoid binary diff issues
- keep custom Image component and width/height props for optimized layout
- reference original PNG images on the websites page

## Testing
- `npm run lint`
- `npm test` *(fails: ENOENT .next/server/app/blog/page.html)*

------
https://chatgpt.com/codex/tasks/task_e_68586cba9ec88321996ecbcbe7612c24