### PR TITLE
Ensure outline buttons remain legible on dark hero sections

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         inverted:
           "bg-white text-neutral-950 hover:bg-white/90 hover:text-neutral-900 focus-visible:ring-neutral-200",
         "outline-inverted":
-          "border border-white/40 bg-transparent text-white hover:bg-white/10 hover:text-white focus-visible:ring-white/60",
+          "border border-white/40 bg-transparent text-white hover:bg-white/10 hover:text-white focus-visible:bg-white/20 focus-visible:text-white focus-visible:ring-white/60 active:bg-white/20 active:text-white",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",


### PR DESCRIPTION
## Summary
- ensure TikTok landing page outline buttons stay transparent with consistent light text in all interaction states
- align Instagram landing page outline buttons with transparent backgrounds and stable focus/active treatments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe5207b8448321a095d524b9bcc352

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the `outline-inverted` Button variant to add focus-visible and active background/text treatments for consistent visibility on dark surfaces.
> 
> - **UI**
>   - **Button component** (`components/ui/button.tsx`):
>     - Updates `buttonVariants` for `variant="outline-inverted"`:
>       - Adds `focus-visible:bg-white/20`, `focus-visible:text-white`, `active:bg-white/20`, `active:text-white` to ensure clear focus/active states while keeping hover behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfdcda2134f2f72f76d8c58884fdbbefd5ece0f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->