### PR TITLE
Fix inverted CTA button states on IG and TikTok pages

### DIFF
--- a/app/ig/instagram-landing-page.tsx
+++ b/app/ig/instagram-landing-page.tsx
@@ -59,14 +59,14 @@ export default function InstagramLandingPage() {
               </p>
             </div>
             <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:items-center">
-              <Button asChild size="lg" className="rounded-full bg-white px-8 py-3 text-base font-semibold text-neutral-950">
+              <Button asChild size="lg" variant="inverted" className="rounded-full px-8 py-3 text-base font-semibold">
                 <Link href="/get-started">Work With Prism</Link>
               </Button>
               <Button
                 asChild
                 size="lg"
-                variant="outline"
-                className="rounded-full border-white/40 px-8 py-3 text-base text-white hover:bg-white/10"
+                variant="outline-inverted"
+                className="rounded-full px-8 py-3 text-base"
               >
                 <Link href="/refer">Refer &amp; Earn</Link>
               </Button>
@@ -187,11 +187,7 @@ export default function InstagramLandingPage() {
                   <br />
                   Let’s design a website that helps your business grow.
                 </p>
-                <Button
-                  asChild
-                  size="lg"
-                  className="rounded-full bg-white px-8 py-3 text-base font-semibold text-neutral-950"
-                >
+                <Button asChild size="lg" variant="inverted" className="rounded-full px-8 py-3 text-base font-semibold">
                   <Link href="/get-started">Get Started</Link>
                 </Button>
               </div>
@@ -204,8 +200,8 @@ export default function InstagramLandingPage() {
                 <Button
                   asChild
                   size="lg"
-                  variant="outline"
-                  className="rounded-full border-white/40 px-8 py-3 text-base text-white hover:bg-white/10"
+                  variant="outline-inverted"
+                  className="rounded-full px-8 py-3 text-base"
                 >
                   <Link href="/refer">Refer &amp; Earn</Link>
                 </Button>

--- a/app/tiktok/tiktok-landing-page.tsx
+++ b/app/tiktok/tiktok-landing-page.tsx
@@ -50,14 +50,14 @@ export default function TikTokLandingPage() {
             </div>
             <p className="text-sm uppercase tracking-[0.3em] text-neutral-400">Clips on TikTok. Clients in real life.</p>
             <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
-              <Button asChild size="lg" className="rounded-full bg-white px-8 py-3 text-base font-semibold text-neutral-950">
+              <Button asChild size="lg" variant="inverted" className="rounded-full px-8 py-3 text-base font-semibold">
                 <Link href="/get-started">→ Work With Prism</Link>
               </Button>
               <Button
                 asChild
                 size="lg"
-                variant="outline"
-                className="rounded-full border-white/40 px-8 py-3 text-base text-white transition hover:bg-white/10"
+                variant="outline-inverted"
+                className="rounded-full px-8 py-3 text-base transition"
               >
                 <Link href="/refer">→ Earn for Referrals</Link>
               </Button>
@@ -163,7 +163,12 @@ export default function TikTokLandingPage() {
                   <p className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-300">If you’re a business owner</p>
                   <p className="mt-3 text-neutral-100">Let’s design a site that grows your business.</p>
                   <div className="mt-4">
-                    <Button asChild size="lg" className="rounded-full bg-white px-6 py-3 text-base font-semibold text-neutral-950">
+                    <Button
+                      asChild
+                      size="lg"
+                      variant="inverted"
+                      className="rounded-full px-6 py-3 text-base font-semibold"
+                    >
                       <Link href="/get-started">Get Started →</Link>
                     </Button>
                   </div>
@@ -175,8 +180,8 @@ export default function TikTokLandingPage() {
                     <Button
                       asChild
                       size="lg"
-                      variant="outline"
-                      className="rounded-full border-white/40 px-6 py-3 text-base text-white hover:bg-white/10"
+                      variant="outline-inverted"
+                      className="rounded-full px-6 py-3 text-base"
                     >
                       <Link href="/refer">Refer &amp; Earn →</Link>
                     </Button>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -14,6 +14,10 @@ const buttonVariants = cva(
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
           "border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground",
+        inverted:
+          "bg-white text-neutral-950 hover:bg-white/90 hover:text-neutral-900 focus-visible:ring-neutral-200",
+        "outline-inverted":
+          "border border-white/40 bg-transparent text-white hover:bg-white/10 hover:text-white focus-visible:ring-white/60",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",


### PR DESCRIPTION
## Summary
- add dedicated inverted and outline-inverted button variants so light CTAs keep consistent hover/focus styling
- update the IG and TikTok landing pages to use the new variants to keep CTA text legible in every state

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68fe539706b08321aa3ebd23da5559f7