### PR TITLE
Update IG and TikTok CTAs to point to pricing

### DIFF
--- a/app/ig/instagram-landing-page.tsx
+++ b/app/ig/instagram-landing-page.tsx
@@ -60,7 +60,7 @@ export default function InstagramLandingPage() {
             </div>
             <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:items-center">
               <Button asChild size="lg" variant="inverted" className="rounded-full px-8 py-3 text-base font-semibold">
-                <Link href="/get-started">Work With Prism</Link>
+                <Link href="/pricing">Work With Prism</Link>
               </Button>
               <Button
                 asChild

--- a/app/tiktok/tiktok-landing-page.tsx
+++ b/app/tiktok/tiktok-landing-page.tsx
@@ -37,7 +37,7 @@ export default function TikTokLandingPage() {
             <p className="text-sm uppercase tracking-[0.3em] text-neutral-400">Clips on TikTok. Clients in real life.</p>
             <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
               <Button asChild size="lg" variant="inverted" className="rounded-full px-8 py-3 text-base font-semibold">
-                <Link href="/get-started">→ Work With Prism</Link>
+                <Link href="/pricing">→ Work With Prism</Link>
               </Button>
               <Button
                 asChild


### PR DESCRIPTION
## Summary
- update the Instagram landing hero CTA to route users to the pricing page
- update the TikTok landing hero CTA to route users to the pricing page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe615d02288321bbf2f605539118de