### PR TITLE
Add Free Analysis CTA to TikTok and Instagram landing pages

### DIFF
--- a/app/ig/instagram-landing-page.tsx
+++ b/app/ig/instagram-landing-page.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic"
 import Link from "next/link"
 
 import Footer from "@/components/footer"
+import FreeAnalysisSection from "@/components/free-analysis-section"
 import { Button } from "@/components/ui/button"
 import { ArrowRight, Check } from "lucide-react"
 
@@ -176,6 +177,8 @@ export default function InstagramLandingPage() {
             </div>
           </div>
         </section>
+
+        <FreeAnalysisSection />
 
         <section className="px-6 py-20 sm:py-24">
           <div className="mx-auto max-w-5xl rounded-3xl bg-neutral-900 px-6 py-16 text-white sm:px-10">

--- a/app/tiktok/tiktok-landing-page.tsx
+++ b/app/tiktok/tiktok-landing-page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link"
 
 import Footer from "@/components/footer"
+import FreeAnalysisSection from "@/components/free-analysis-section"
 import Navbar from "@/components/navbar"
 import ScrollToTop from "@/components/scroll-to-top"
 import { Button } from "@/components/ui/button"
@@ -139,6 +140,8 @@ export default function TikTokLandingPage() {
             </div>
           </div>
         </section>
+
+        <FreeAnalysisSection />
 
         <section className="border-b border-neutral-200 bg-neutral-950 text-white">
           <div className="mx-auto flex max-w-5xl flex-col gap-10 px-4 py-20 sm:py-24">

--- a/components/free-analysis-section.tsx
+++ b/components/free-analysis-section.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import Link from "next/link"
+
+import { Button } from "@/components/ui/button"
+
+const benefits = [
+  "Personalized teardown of your current site",
+  "Actionable roadmap covering design, SEO, and growth",
+  "No obligation — just clarity on what to do next",
+]
+
+export default function FreeAnalysisSection() {
+  return (
+    <section className="relative border-b border-neutral-200 bg-neutral-950 text-white">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_55%)]" />
+      <div className="absolute inset-0 bg-[linear-gradient(135deg,_rgba(255,255,255,0.12),_rgba(12,12,12,0.95))] opacity-60" />
+      <div className="relative mx-auto flex max-w-5xl flex-col gap-12 px-4 py-20 sm:px-6 sm:py-24">
+        <div className="flex flex-col gap-4">
+          <span className="w-fit rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
+            Free Analysis
+          </span>
+          <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+            See what Prism would build for you — before you ever sign.
+          </h2>
+          <p className="max-w-2xl text-base text-neutral-200 sm:text-lg">
+            Claim a complimentary analysis where we review your site, surface hidden opportunities, and map the exact upgrades that will unlock your next stage of growth.
+          </p>
+        </div>
+        <div className="grid gap-10 lg:grid-cols-[1.1fr,0.9fr] lg:items-center">
+          <ul className="space-y-4 text-base text-neutral-100 sm:text-lg">
+            {benefits.map((benefit) => (
+              <li key={benefit} className="flex items-start gap-3">
+                <span className="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-white" />
+                <span className="text-neutral-200">{benefit}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="rounded-3xl border border-white/15 bg-white/5 p-8 text-neutral-100 shadow-[0_20px_45px_-20px_rgba(0,0,0,0.7)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-white/70">What you’ll receive</p>
+            <p className="mt-3 text-base text-neutral-200 sm:text-lg">
+              A 10-minute loom recording, prioritized action items, and the exact next steps to turn attention into revenue.
+            </p>
+            <div className="mt-6">
+              <Button
+                asChild
+                size="lg"
+                variant="inverted"
+                className="w-full rounded-full px-8 py-3 text-base font-semibold text-neutral-950"
+              >
+                <Link href="/get-started">Claim Your Free Analysis</Link>
+              </Button>
+              <p className="mt-3 text-xs text-white/60">
+                We’ll respond within one business day.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add a reusable Free Analysis section that highlights the complimentary website review
- surface the new section on the TikTok and Instagram landing pages to drive visitors toward the offer

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68fe62fc54f88321978809455a23a500