### PR TITLE
Remove duplicate hero tagline on Instagram landing page

### DIFF
--- a/app/ig/instagram-landing-page.tsx
+++ b/app/ig/instagram-landing-page.tsx
@@ -32,8 +32,7 @@ export default function InstagramLandingPage() {
           <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_60%)]" />
           <div className="absolute inset-0 -z-10 bg-[conic-gradient(from_120deg,_rgba(255,255,255,0.12),_rgba(13,13,13,0.8))] opacity-40" />
           <div className="mx-auto max-w-4xl px-6 py-24 sm:py-28 md:py-32">
-            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-neutral-300">From inspiration to action</p>
-            <h1 className="mt-6 text-4xl font-semibold leading-tight tracking-tight sm:text-5xl md:text-6xl">
+            <h1 className="text-4xl font-semibold leading-tight tracking-tight sm:text-5xl md:text-6xl">
               From Inspiration to Action
             </h1>
             <div className="mt-6 space-y-4 text-base text-neutral-200 sm:text-lg">


### PR DESCRIPTION
## Summary
- remove the redundant small caption from the Instagram landing page hero
- adjust the main heading spacing to keep the layout balanced after the removal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fec229aab0832189827aa5847a0020