### PR TITLE
Add Google Analytics page view tracking to social community pages

### DIFF
--- a/app/ig/instagram-landing-page.tsx
+++ b/app/ig/instagram-landing-page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 
 import Footer from "@/components/footer"
 import FreeAnalysisSection from "@/components/free-analysis-section"
+import PageViewTracker from "@/components/page-view-tracker"
 import { Button } from "@/components/ui/button"
 import { ArrowRight, Check } from "lucide-react"
 
@@ -28,6 +29,7 @@ export default function InstagramLandingPage() {
     <div className="flex min-h-screen flex-col bg-white text-neutral-900">
       <Navbar />
       <main className="flex-1">
+        <PageViewTracker title="Instagram Community" />
         <section className="relative overflow-hidden border-b border-neutral-200 bg-neutral-950 text-white">
           <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_60%)]" />
           <div className="absolute inset-0 -z-10 bg-[conic-gradient(from_120deg,_rgba(255,255,255,0.12),_rgba(13,13,13,0.8))] opacity-40" />

--- a/app/tiktok/tiktok-landing-page.tsx
+++ b/app/tiktok/tiktok-landing-page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import Footer from "@/components/footer"
 import FreeAnalysisSection from "@/components/free-analysis-section"
 import Navbar from "@/components/navbar"
+import PageViewTracker from "@/components/page-view-tracker"
 import ScrollToTop from "@/components/scroll-to-top"
 import { Button } from "@/components/ui/button"
 
@@ -14,6 +15,7 @@ export default function TikTokLandingPage() {
       <Navbar />
       <ScrollToTop />
       <main className="flex-1">
+        <PageViewTracker title="TikTok Community" />
         <section className="relative overflow-hidden border-b border-neutral-200 bg-neutral-950 text-white">
           <div className="absolute inset-0">
             <div className="absolute inset-0 bg-gradient-to-br from-neutral-900/95 via-neutral-900/85 to-neutral-950" />

--- a/app/youtube/youtube-landing-page.tsx
+++ b/app/youtube/youtube-landing-page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 
 import Footer from "@/components/footer"
 import FreeAnalysisSection from "@/components/free-analysis-section"
+import PageViewTracker from "@/components/page-view-tracker"
 import { Button } from "@/components/ui/button"
 import { ArrowRight, Check, Play } from "lucide-react"
 
@@ -43,6 +44,7 @@ export default function YouTubeLandingPage() {
     <div className="flex min-h-screen flex-col bg-white text-neutral-900">
       <Navbar />
       <main className="flex-1">
+        <PageViewTracker title="YouTube Community" />
         <section className="relative overflow-hidden border-b border-neutral-200 bg-neutral-950 text-white">
           <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_60%)]" />
           <div className="absolute inset-0 -z-10 bg-[conic-gradient(from_120deg,_rgba(255,255,255,0.12),_rgba(13,13,13,0.8))] opacity-40" />


### PR DESCRIPTION
## Summary
- add the shared PageViewTracker component to the Instagram, YouTube, and TikTok landing pages so that GA receives explicit page view events

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ff851ef3348321968ab01196ccd872