### PR TITLE
Document running typecheck and tests in development guide

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -6,6 +6,7 @@ This guide highlights the workflows we lean on most often while iterating on the
 - Install deps with `pnpm install` (repo assumes pnpm).
 - Start the Next.js dev server with `pnpm dev`.
 - Run `pnpm lint` before committing so the shared Tailwind + ESLint rules stay consistent.
+- Run `pnpm typecheck` and `pnpm test` before opening a PR (combine as `pnpm lint && pnpm typecheck && pnpm test`).
 - Run `pnpm test:visual` before merging changes that touch the UI of `/`, `/about`, or `/pricing` (screenshot-locked routes).
 
 ## Styling Pipeline


### PR DESCRIPTION
### Motivation
- Ensure contributors run `pnpm typecheck` and `pnpm test` alongside `pnpm lint` before opening a PR to catch type and test regressions early.

### Description
- Add a checklist item in `docs/development-guide.md` instructing to run `pnpm typecheck` and `pnpm test` and suggesting the combined command `pnpm lint && pnpm typecheck && pnpm test`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981549221a083219e9a0d095ad51ff1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates contributor workflow guidance without affecting runtime code or CI behavior.
> 
> **Overview**
> Updates `docs/development-guide.md` to explicitly ask contributors to run `pnpm typecheck` and `pnpm test` (in addition to `pnpm lint`) before opening a PR, including a suggested combined command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d0436f5279c7308780199116cd501b45b7769b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->