### PR TITLE
Add Unicorn Studio hero scene to homepage

### DIFF
--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -6,6 +6,7 @@ import PixelishIcon from "@/components/pixelish/PixelishIcon"
 import Footer from "@/components/footer"
 import ScalingRoadmapForm from "@/components/forms/ScalingRoadmapForm"
 import HeroBenefits from "@/components/home/HeroBenefits"
+import UnicornHeroScene from "@/components/home/UnicornHeroScene"
 import WallOfLoveCarousel from "@/components/home/WallOfLoveCarousel"
 import SearchConsoleSnapshotsRail from "@/components/home/SearchConsoleSnapshotsRail"
 import Navbar from "@/components/navbar"
@@ -248,6 +249,7 @@ export default function ClientPage() {
       <Navbar mobileRevealOnFirstTap />
       <main className="flex-1">
         <section className={HERO_SECTION_CLASSES}>
+          <UnicornHeroScene className="absolute inset-0 -z-10" />
           <div className="container relative mx-auto px-4 sm:px-6">
             <div className="mx-auto max-w-2xl space-y-6 text-center lg:max-w-3xl">
               <div className="space-y-4">

--- a/components/home/UnicornHeroScene.tsx
+++ b/components/home/UnicornHeroScene.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { useEffect } from "react"
+
+const PROJECT_ID = "IJcFJOBrS3f58k1ZR3JY"
+const SDK_URL =
+  "https://cdn.jsdelivr.net/gh/hiunicornstudio/unicornstudio.js@v2.0.5/dist/unicornStudio.umd.js"
+const SCRIPT_ID = "unicornstudio-sdk"
+
+declare global {
+  interface Window {
+    UnicornStudio?: {
+      init?: () => void
+    }
+  }
+}
+
+type UnicornHeroSceneProps = {
+  className?: string
+}
+
+const initUnicornStudio = () => {
+  if (typeof window === "undefined") return
+  window.UnicornStudio?.init?.()
+}
+
+const ensureUnicornScript = () => {
+  if (typeof document === "undefined") return
+  const existingScript = document.getElementById(SCRIPT_ID)
+
+  if (existingScript) {
+    initUnicornStudio()
+    return
+  }
+
+  const script = document.createElement("script")
+  script.id = SCRIPT_ID
+  script.src = SDK_URL
+  script.async = true
+  script.onload = () => {
+    initUnicornStudio()
+  }
+
+  document.head.appendChild(script)
+}
+
+export default function UnicornHeroScene({ className }: UnicornHeroSceneProps) {
+  useEffect(() => {
+    ensureUnicornScript()
+  }, [])
+
+  return (
+    <div
+      className={className}
+      data-us-project={PROJECT_ID}
+      style={{ width: "100%", height: "100%" }}
+      aria-hidden="true"
+    />
+  )
+}

--- a/docs/pages-overview.md
+++ b/docs/pages-overview.md
@@ -63,6 +63,7 @@ Quick reference for the pages we edit most often.
 - The hero client logo circles use click/tap tooltips; keep the label text in `HERO_CLIENT_ICONS` aligned with the logos.
 - Hero benefit cards are rendered by `components/home/HeroBenefits.tsx`, including randomized Lordicon variants on each load for the “more customers”, “Higher Customer LTV”, and “spend less time on tech” tiles.
 - The hero section uses `HERO_SECTION_CLASSES` in `app/client-page.tsx` to center its content in the viewport while accounting for the sticky header height and safe-area insets.
+- The homepage hero background animation is embedded via `components/home/UnicornHeroScene.tsx`, which loads the Unicorn Studio SDK and mounts the WebGL scene behind the hero copy.
 - On mobile, the homepage navbar starts hidden and fades/slides in after the first tap; this is enabled via `mobileRevealOnFirstTap` on `components/navbar.tsx`.
 - Homepage sections use full-screen spacing (`SECTION_SPACING` in `app/client-page.tsx` plus the matching padding in `components/home/WallOfLoveCarousel.tsx`) so each section reads as its own viewport.
 - The Search Console snapshots section below the hero uses `components/home/SearchConsoleSnapshotsRail.tsx` (native scroll-snap rail with lightweight arrow controls for desktop); keep it touch-first with subtle progress bars under the rail.


### PR DESCRIPTION
### Motivation
- Add an immersive, WebGL-backed background animation to the homepage hero to improve visual engagement using the Unicorn Studio embed.
- Keep the animation client-only and load the Unicorn Studio SDK dynamically so server rendering and build-time behavior remain unaffected.

### Description
- Add `components/home/UnicornHeroScene.tsx`, a client component that injects the Unicorn Studio SDK script and mounts a `div` with `data-us-project` for project `IJcFJOBrS3f58k1ZR3JY` using SDK `v2.0.5`.
- Mount `UnicornHeroScene` behind the hero content in `app/client-page.tsx` with `className="absolute inset-0 -z-10"` so the scene renders as the hero background.
- Document the new homepage hero animation entry in `docs/pages-overview.md`.

### Testing
- Started a local dev server with `pnpm exec next dev -H 0.0.0.0 -p 3000`, which booted and served the site successfully.
- Ran a Playwright script that navigated to `http://localhost:3000` and captured a screenshot saved as `artifacts/home-hero-unicorn.png`, which completed successfully.
- Observed unrelated Next.js image proxy fetch warnings (`ENETUNREACH`) for external images but the homepage rendered and the visual verification succeeded.
- No unit or Jest tests were run as part of this change (`pnpm test` not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a5546eaa883219d6288a69979676f)