### PR TITLE
Use unicornstudio-react for homepage hero animation

### DIFF
--- a/components/home/UnicornHeroScene.tsx
+++ b/components/home/UnicornHeroScene.tsx
@@ -1,60 +1,24 @@
 "use client"
 
-import { useEffect } from "react"
+import UnicornScene from "unicornstudio-react/next"
 
 const PROJECT_ID = "IJcFJOBrS3f58k1ZR3JY"
 const SDK_URL =
   "https://cdn.jsdelivr.net/gh/hiunicornstudio/unicornstudio.js@v2.0.5/dist/unicornStudio.umd.js"
-const SCRIPT_ID = "unicornstudio-sdk"
-
-declare global {
-  interface Window {
-    UnicornStudio?: {
-      init?: () => void
-    }
-  }
-}
 
 type UnicornHeroSceneProps = {
   className?: string
 }
 
-const initUnicornStudio = () => {
-  if (typeof window === "undefined") return
-  window.UnicornStudio?.init?.()
-}
-
-const ensureUnicornScript = () => {
-  if (typeof document === "undefined") return
-  const existingScript = document.getElementById(SCRIPT_ID)
-
-  if (existingScript) {
-    initUnicornStudio()
-    return
-  }
-
-  const script = document.createElement("script")
-  script.id = SCRIPT_ID
-  script.src = SDK_URL
-  script.async = true
-  script.onload = () => {
-    initUnicornStudio()
-  }
-
-  document.head.appendChild(script)
-}
-
 export default function UnicornHeroScene({ className }: UnicornHeroSceneProps) {
-  useEffect(() => {
-    ensureUnicornScript()
-  }, [])
-
   return (
-    <div
-      className={className}
-      data-us-project={PROJECT_ID}
-      style={{ width: "100%", height: "100%" }}
-      aria-hidden="true"
-    />
+    <div className={className} aria-hidden="true">
+      <UnicornScene
+        projectId={PROJECT_ID}
+        sdkUrl={SDK_URL}
+        width="100%"
+        height="100%"
+      />
+    </div>
   )
 }

--- a/docs/pages-overview.md
+++ b/docs/pages-overview.md
@@ -62,11 +62,9 @@ Quick reference for the pages we edit most often.
 - Hero copy, service strip, and CTAs live in `app/client-page.tsx` with CTA tracking in `components/home/HeroCtas.tsx`.
 - The hero client logo circles use click/tap tooltips; keep the label text in `HERO_CLIENT_ICONS` aligned with the logos.
 - Hero benefit cards are rendered by `components/home/HeroBenefits.tsx`, including randomized Lordicon variants on each load for the “more customers”, “Higher Customer LTV”, and “spend less time on tech” tiles.
-- The hero section uses `HERO_SECTION_CLASSES` in `app/client-page.tsx` to reserve a full-viewport slot for the Unicorn Studio animation, accounting for the sticky header height and safe-area insets.
-- The homepage hero background animation is embedded via `components/home/UnicornHeroScene.tsx`, which loads the Unicorn Studio SDK and mounts the WebGL scene as the entire hero section.
-- The main hero copy, CTA, benefits, and client logos now live in the section immediately following the animation.
-- The hero section uses `HERO_SECTION_CLASSES` in `app/client-page.tsx` to center its content in the viewport while accounting for the sticky header height and safe-area insets.
-- The homepage hero background animation is embedded via `components/home/UnicornHeroScene.tsx`, which loads the Unicorn Studio SDK and mounts the WebGL scene behind the hero copy.
+- The hero animation section uses `HERO_SECTION_CLASSES` in `app/client-page.tsx` to reserve a full-viewport slot, accounting for the sticky header height and safe-area insets.
+- The Unicorn Studio WebGL scene is embedded via `components/home/UnicornHeroScene.tsx` using `unicornstudio-react/next` and mounts as a standalone hero section.
+- The main hero copy, CTA, benefits, and client logos live in the section immediately following the animation.
 - On mobile, the homepage navbar starts hidden and fades/slides in after the first tap; this is enabled via `mobileRevealOnFirstTap` on `components/navbar.tsx`.
 - Homepage sections use full-screen spacing (`SECTION_SPACING` in `app/client-page.tsx` plus the matching padding in `components/home/WallOfLoveCarousel.tsx`) so each section reads as its own viewport.
 - The Search Console snapshots section below the hero uses `components/home/SearchConsoleSnapshotsRail.tsx` (native scroll-snap rail with lightweight arrow controls for desktop); keep it touch-first with subtle progress bars under the rail.

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
+    "unicornstudio-react": "2.0.1-1",
     "unified": "latest",
     "unist-util-visit": "latest",
     "vaul": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.1.18)
+      unicornstudio-react:
+        specifier: 2.0.1-1
+        version: 2.0.1-1(next@16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       unified:
         specifier: latest
         version: 11.0.5
@@ -5572,6 +5575,17 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unicornstudio-react@2.0.1-1:
+    resolution: {integrity: sha512-+k2fskodRSLFGoq2Oj1YYbmweRb0sNl0sztq1yoJhNHfIKSINFy2q1nFIfzfVjx34NDnPckw1iIhwVk02DQUtw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      next: '*'
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+    peerDependenciesMeta:
+      next:
+        optional: true
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -12101,6 +12115,13 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  unicornstudio-react@2.0.1-1(next@16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      next: 16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
### Motivation
- Replace the manual SDK injection with the official React integration so the Unicorn Studio WebGL scene can be mounted as a standalone hero section above the main hero copy. 

### Description
- Replace manual script injection and data-attribute container in `components/home/UnicornHeroScene.tsx` with the `<UnicornScene>` component from `unicornstudio-react/next`, passing `projectId`, `sdkUrl`, `width`, and `height`.
- Keep the animation as a dedicated full-viewport hero section so the main hero copy, CTAs, benefits, and client logos live in the following section and are unaffected by the WebGL mount.
- Update `docs/pages-overview.md` to document the new hero animation section and the React-based embed approach.
- Add the `unicornstudio-react` dependency and update the lockfile.

### Testing
- Ran `pnpm add unicornstudio-react`, which completed successfully.
- Started the dev server with `pnpm dev`, which launched successfully (Next logged unrelated image proxy warnings during startup). 
- Ran a Playwright script that navigated to `http://localhost:3000` and saved a screenshot to `artifacts/homepage-hero.png`, and the script completed successfully after a retry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a5948be548321b10222945584c223)