### PR TITLE
Tune hero animation fit on mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -424,6 +424,24 @@ input, textarea, select {
 .hero-section {
   contain: layout style paint;
 }
+
+.unicorn-hero-scene {
+  height: 100%;
+  width: 100%;
+}
+
+.unicorn-hero-scene > div,
+.unicorn-hero-scene canvas {
+  height: 100%;
+  width: 100%;
+}
+
+@media (max-width: 640px) {
+  .unicorn-hero-scene {
+    transform: scale(0.88);
+    transform-origin: center;
+  }
+}
   
   /* Prevent layout shifts */
   .preserve-aspect {

--- a/components/home/UnicornHeroScene.tsx
+++ b/components/home/UnicornHeroScene.tsx
@@ -11,8 +11,10 @@ type UnicornHeroSceneProps = {
 }
 
 export default function UnicornHeroScene({ className }: UnicornHeroSceneProps) {
+  const rootClassName = ["unicorn-hero-scene", className].filter(Boolean).join(" ")
+
   return (
-    <div className={className} aria-hidden="true">
+    <div className={rootClassName} aria-hidden="true">
       <UnicornScene
         jsonFilePath={JSON_FILE_PATH}
         sdkUrl={SDK_URL}


### PR DESCRIPTION
### Motivation
- The hero animation (Unicorn scene) was clipping marquee text on narrow viewports, so the animation needed a responsive wrapper and mobile scale to keep text visible on phones.

### Description
- Add a dedicated wrapper class by merging `className` with `unicorn-hero-scene` in `components/home/UnicornHeroScene.tsx` so the animation can be targeted by CSS.
- Add CSS rules in `app/globals.css` to make the wrapper and its inner `div`/`canvas` fill their container and to scale the scene down on small screens with `@media (max-width: 640px)`.
- Ensure the scene continues to render at `width="100%"` and `height="100%"` so scaling behaves predictably.

### Testing
- Installed dependencies via `pnpm install` which added `unicornstudio-react` to resolve a missing-module build error. (succeeded)
- Started the dev server with `pnpm dev` to verify the application compiles after the dependency addition. (server started)
- Ran a Playwright visual smoke attempt to capture a mobile screenshot, but Chromium crashed intermittently in this environment so reliable visual verification could not be completed. (failed intermittently)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a5eedb11883219ca74e70b4b03cc8)