### PR TITLE
Shrink software tool icons across app cards

### DIFF
--- a/lib/software-apps.ts
+++ b/lib/software-apps.ts
@@ -21,7 +21,7 @@ export const PRISM_APPS: SoftwareApp[] = [
     icon: {
       src: "/pixelish/bar-chart-average.svg",
       alt: "Density app icon",
-      size: 28,
+      size: 6,
     },
   },
   {
@@ -33,7 +33,7 @@ export const PRISM_APPS: SoftwareApp[] = [
     icon: {
       src: "/pixelish/media-play.svg",
       alt: "Hot Content app icon",
-      size: 28,
+      size: 6,
     },
   },
   {
@@ -44,7 +44,7 @@ export const PRISM_APPS: SoftwareApp[] = [
     icon: {
       src: "/pixelish/command.svg",
       alt: "Engineering Tracker app icon",
-      size: 28,
+      size: 6,
     },
   },
 ]


### PR DESCRIPTION
## Summary
- reduced the shared `PRISM_APPS` icon size from `28` to `6`
- this makes the icons in the “Tools to Help You Grow” cards much smaller on both:
  - homepage section
  - `/software` page
- because both pages use the same `PRISM_APPS` source, one update keeps sizing consistent

## Validation
- started the Next.js dev server and visually checked `/` and `/software`
- captured updated screenshots for both pages

## Screenshots
- Home: `browser:/tmp/codex_browser_invocations/95e8a3b31f6353d3/artifacts/artifacts/home-tools-icons-small.png`
- Software: `browser:/tmp/codex_browser_invocations/95e8a3b31f6353d3/artifacts/artifacts/software-tools-icons-small.png`

## Rollout considerations
- no data migrations or config changes
- purely presentational icon-size update

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b81b87a348321914fa8ed9039aee4)