### PR TITLE
Add top-of-page “Visit client site” buttons to case studies

### DIFF
--- a/app/case-studies/dr-christopher-wong/client-page.tsx
+++ b/app/case-studies/dr-christopher-wong/client-page.tsx
@@ -2,11 +2,13 @@ import Footer from "@/components/footer"
 import Navbar from "@/components/navbar"
 import { CaseStudySchema } from "@/components/schema-markup"
 import SocialShare from "@/components/social-share"
+import { Button } from "@/components/ui/button"
 import Link from "next/link"
 const linkClassName =
   "font-medium text-foreground underline decoration-border/60 underline-offset-4 hover:decoration-border"
 const CASE_STUDY_TITLE = "case study: dr. wong — de-risking a dental m&a in palo alto with ai-powered marketing"
 const CASE_STUDY_DESCRIPTION = "from ownership transition risk to a future-proof, ai-powered dental practice in palo alto."
+const CLIENT_SITE = "https://www.chriswongdds.com"
 
 export default function ChristopherWongCaseStudy() {
   return (
@@ -32,6 +34,13 @@ export default function ChristopherWongCaseStudy() {
               watch enzo’s interview with dr. wong on how the handoff worked, what changed across the site and local presence, and how ai-first workflows
               now power the practice.
             </p>
+            <div className="not-prose">
+              <Button asChild variant="outline" className="rounded-full">
+                <Link href={CLIENT_SITE} target="_blank" rel="noopener noreferrer">
+                  visit chriswongdds.com
+                </Link>
+              </Button>
+            </div>
             <p>
               visit the practice site at <strong>chriswongdds.com</strong>.
             </p>

--- a/app/case-studies/exquisite-dentistry/client-page.tsx
+++ b/app/case-studies/exquisite-dentistry/client-page.tsx
@@ -2,6 +2,7 @@ import Footer from "@/components/footer"
 import Navbar from "@/components/navbar"
 import { CaseStudySchema } from "@/components/schema-markup"
 import SocialShare from "@/components/social-share"
+import { Button } from "@/components/ui/button"
 import Image from "next/image"
 const EXQUISITE_SITE = "https://exquisitedentistryla.com/?utm_source=chatgpt.com"
 const EXQUISITE_SITE_TITLE = "Exquisite Dentistry: Cosmetic Dentist Los Angeles | Dr. Aguil"
@@ -34,6 +35,13 @@ export default function ExquisiteDentistryCaseStudy() {
             <p>
               <strong>Scope:</strong> Website rebuild, SEO preservation + upgrades, local listings cleanup, funnel + forms rebuild, analytics + attribution, ongoing optimization
             </p>
+            <div className="not-prose">
+              <Button asChild variant="outline" className="rounded-full">
+                <a href={EXQUISITE_SITE} title={EXQUISITE_SITE_TITLE} target="_blank" rel="noopener noreferrer">
+                  visit exquisitedentistryla.com
+                </a>
+              </Button>
+            </div>
             <hr />
 
             <h2>“We’re one of the best practices in the city… so why does our website look like it isn’t?”</h2>

--- a/app/case-studies/mataria-dental-group/client-page.tsx
+++ b/app/case-studies/mataria-dental-group/client-page.tsx
@@ -20,6 +20,7 @@ const FounderImpactGraph = dynamic(
 )
 
 const HERO_VIDEO_ID = "VIDEO_PLACEHOLDER"
+const CLIENT_SITE = "https://www.matariadental.com"
 const cs = CASE_STUDIES.find((item) => item.slug === "mataria-dental-group")
 
 type ListItem = {
@@ -578,6 +579,13 @@ export default function MatariaDentalGroupCaseStudy() {
               <p className="text-neutral-700">
                 Prism partnered with Dr. Mataria - a multi-location dentist and implant educator - to relaunch Mataria Dental Group in Torrance, retain the existing patient base, and spin up a modern web + content + social engine for growth.
               </p>
+              <div>
+                <Button asChild variant="outline" className="rounded-full">
+                  <Link href={CLIENT_SITE} target="_blank" rel="noopener noreferrer">
+                    visit matariadental.com
+                  </Link>
+                </Button>
+              </div>
               <div className="flex flex-wrap gap-2 pt-2">
                 {quickFacts.map((fact) => (
                   <div key={fact.label} className="rounded-full border border-neutral-200 bg-white px-3 py-1 text-sm text-neutral-700">

--- a/app/case-studies/olympic-bootworks/client-page.tsx
+++ b/app/case-studies/olympic-bootworks/client-page.tsx
@@ -1,6 +1,7 @@
 import Footer from "@/components/footer"
 import Navbar from "@/components/navbar"
 import { CaseStudySchema } from "@/components/schema-markup"
+import { Button } from "@/components/ui/button"
 import SocialShare from "@/components/social-share"
 import Image from "next/image"
 import Link from "next/link"
@@ -10,6 +11,7 @@ const linkClassName =
 const CASE_STUDY_TITLE = "Olympic Bootworks: the Tahoe shop that finally sells online"
 const CASE_STUDY_DESCRIPTION =
   "Olympic Bootworks already had the hard part: a legendary reputation, Olympians in the fitting room, and customers who drive hours to get it done right."
+const CLIENT_SITE = "https://www.olympicbootworks.com"
 
 export default function OlympicBootworksCaseStudy() {
   return (
@@ -32,6 +34,13 @@ export default function OlympicBootworksCaseStudy() {
               Prism rebuilt Olympic Bootworks into a two‑site ecommerce system—POS‑linked inventory, a dedicated Fantic Warehouse microsite, and an owned
               Google + email stack—so the shop can sell while the team stays focused on bootfitting.
             </p>
+            <div className="not-prose">
+              <Button asChild variant="outline" className="rounded-full">
+                <Link href={CLIENT_SITE} target="_blank" rel="noopener noreferrer">
+                  visit olympicbootworks.com
+                </Link>
+              </Button>
+            </div>
             <p>
               <strong>Location:</strong> Tahoe, CA
               <br />

--- a/app/case-studies/saorsa-growth-partners/client-page.tsx
+++ b/app/case-studies/saorsa-growth-partners/client-page.tsx
@@ -13,6 +13,7 @@ const FounderImpactGraph = dynamic(
 )
 
 const CASE_STUDY_SLUG = "saorsa-growth-partners"
+const CLIENT_SITE = "https://www.saorsagrowthpartners.com"
 const CANONICAL_URL = `https://www.design-prism.com/case-studies/${CASE_STUDY_SLUG}`
 const caseStudy = CASE_STUDIES.find((study) => study.slug === CASE_STUDY_SLUG)
 const schemaTitle = caseStudy?.title ?? "Growth Systems for a Boutique Consultancy"
@@ -45,7 +46,10 @@ export default function SaorsaGrowthPartnersCaseStudy() {
               <span className="rounded-full bg-neutral-100 px-3 py-1">services overview</span>
               <span className="rounded-full bg-neutral-100 px-3 py-1">fast contact paths</span>
             </div>
-            <div className="pt-6">
+            <div className="flex flex-wrap gap-3 pt-6">
+              <Button asChild variant="outline" className="rounded-full lowercase">
+                <Link href={CLIENT_SITE} target="_blank" rel="noopener noreferrer">visit saorsagrowthpartners.com</Link>
+              </Button>
               <Button asChild className="rounded-full lowercase">
                 <Link href="/contact">start a project</Link>
               </Button>

--- a/components/case-study-minimal.tsx
+++ b/components/case-study-minimal.tsx
@@ -98,6 +98,14 @@ export default function MinimalCaseStudyPage({
 }: MinimalCaseStudyProps) {
   const ctaHref = cta?.href ?? "/get-started"
   const ctaTrackLabel = cta?.trackLabel ?? `${pageTrackingTitle.toLowerCase()} case study`
+  const websiteFact = quickFacts.find((fact) => fact.label.toLowerCase() === "website" && Boolean(fact.href))
+  const resolvedHeroButton = heroButton ?? (websiteFact?.href
+    ? {
+      label: `visit ${websiteFact.value}`,
+      href: websiteFact.href,
+      trackLabel: `${pageTrackingTitle.toLowerCase()} client website`,
+    }
+    : undefined)
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -113,26 +121,26 @@ export default function MinimalCaseStudyPage({
               <h1 className="text-balance text-4xl font-bold tracking-tight sm:text-6xl">{heroTitle}</h1>
               {heroSubtitle && <p className="text-lg text-muted-foreground sm:text-xl">{heroSubtitle}</p>}
               <p className="text-muted-foreground">{summary}</p>
-              {heroButton && (
+              {resolvedHeroButton && (
                 <div className="flex flex-wrap items-center gap-3">
                   <Button asChild variant="outline" className="rounded-full">
-                    {heroButton.trackLabel ? (
+                    {resolvedHeroButton.trackLabel ? (
                       <TrackedLink
-                        href={heroButton.href}
-                        target={heroButton.href.startsWith("http") ? "_blank" : undefined}
-                        rel={heroButton.href.startsWith("http") ? "noopener noreferrer" : undefined}
-                        label={heroButton.label}
-                        location={heroButton.trackLabel}
+                        href={resolvedHeroButton.href}
+                        target={resolvedHeroButton.href.startsWith("http") ? "_blank" : undefined}
+                        rel={resolvedHeroButton.href.startsWith("http") ? "noopener noreferrer" : undefined}
+                        label={resolvedHeroButton.label}
+                        location={resolvedHeroButton.trackLabel}
                       >
-                        {heroButton.label}
+                        {resolvedHeroButton.label}
                       </TrackedLink>
                     ) : (
                       <Link
-                        href={heroButton.href}
-                        target={heroButton.href.startsWith("http") ? "_blank" : undefined}
-                        rel={heroButton.href.startsWith("http") ? "noopener noreferrer" : undefined}
+                        href={resolvedHeroButton.href}
+                        target={resolvedHeroButton.href.startsWith("http") ? "_blank" : undefined}
+                        rel={resolvedHeroButton.href.startsWith("http") ? "noopener noreferrer" : undefined}
                       >
-                        {heroButton.label}
+                        {resolvedHeroButton.label}
                       </Link>
                     )}
                   </Button>

--- a/docs/pages-overview.md
+++ b/docs/pages-overview.md
@@ -8,7 +8,7 @@ Quick reference for the pages we edit most often.
 - Reusable “data note / in progress” callouts are `components/case-studies/CaseStudyCallout.tsx` (shadcn `Alert`).
 - The “buy back time / grow customers” interactive graph is `components/case-studies/FounderImpactGraph.tsx` (shadcn `Tabs` + recharts; “with prism” vs “without prism” scenarios).
 - The shared curve/data generator lives in `lib/case-study-impact-graph.ts` (bounded 0–100 index with exponential “customers compound” growth + “effort decays to zero”; tune via `curves.*K` if we ever switch to case-specific numbers).
-- Minimal case studies use `components/case-study-minimal.tsx`, which automatically includes the graph so pages stay consistent.
+- Minimal case studies use `components/case-study-minimal.tsx`, which automatically includes the graph and now surfaces a top-of-page "visit <client-site>" button whenever a `website` quick fact includes an external `href`.
 
 ## Pricing (`app/pricing/client-page.tsx`)
 - Core sections (plans grid, founder VSL block, “everything included” features, “Website Use Cases”, smooth handoff section, clients rail, FAQ, and final CTA) live here; the hero + fullscreen modal live in `components/pricing/PricingHero.tsx`.


### PR DESCRIPTION
### Motivation
- Improve discoverability and consistency by surfacing a clear top-of-page CTA that opens the client’s live site in a new tab on case study pages. 

### Description
- Added a reusable fallback in `components/case-study-minimal.tsx` that automatically shows a hero button when a `quickFacts` entry has `label: "website"` with an external `href`, while preserving any explicit `heroButton` prop. 
- Inserted top-level client-site CTA buttons (open in new tab with `target="_blank"` and `rel="noopener noreferrer"`) into long-form case studies: `app/case-studies/dr-christopher-wong/client-page.tsx`, `app/case-studies/exquisite-dentistry/client-page.tsx`, `app/case-studies/olympic-bootworks/client-page.tsx`, `app/case-studies/mataria-dental-group/client-page.tsx`, and `app/case-studies/saorsa-growth-partners/client-page.tsx`. 
- Documented the new minimal-case-study behavior in `docs/pages-overview.md`. 

### Testing
- Ran lint with `pnpm lint` and the lint run completed successfully. 
- Ran type checking with `pnpm typecheck` (`tsc --noEmit`) and the typecheck completed successfully. 
- Started the dev server and captured a visual smoke-test screenshot via a Playwright script to validate the new hero button rendered on a case study page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b82ba8cb08321b2160c57d95841a3)