### PR TITLE
Fix Next.js build failure in HeroMonthlyLeadsPill

### DIFF
--- a/components/home/HeroMonthlyLeadsPill.tsx
+++ b/components/home/HeroMonthlyLeadsPill.tsx
@@ -18,7 +18,6 @@ export default function HeroMonthlyLeadsPill({ className }: HeroMonthlyLeadsPill
     <Link
       href="/case-studies"
       aria-label={`View case studies: ${leadsText} leads delivered to clients last month. Stat updated monthly.`}
-      aria-label={`View case studies: ${leadsText} leads delivered to clients in last month. Stat updated monthly.`}
       className={cn(
         "group relative inline-flex w-fit max-w-[25rem] flex-col items-center justify-center gap-1 rounded-[1.5rem] border border-border/60 bg-background/80 px-4 py-3 text-center text-xs text-muted-foreground shadow-[0_18px_50px_-32px_rgba(0,0,0,0.45)] backdrop-blur-sm transition-[transform,box-shadow,border-color,background-color] duration-200 ease-out hover:-translate-y-0.5 hover:border-border/80 hover:bg-background/90 hover:shadow-[0_26px_60px_-34px_rgba(0,0,0,0.55)] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:px-6 sm:py-3.5 sm:text-sm",
         className,
@@ -26,7 +25,6 @@ export default function HeroMonthlyLeadsPill({ className }: HeroMonthlyLeadsPill
     >
       <span className="max-w-[20rem] font-semibold leading-snug text-foreground sm:max-w-none">
         {leadsText} leads delivered to clients last month 🥳
-        {leadsText} leads delivered to clients in last month 🥳
       </span>
       <span className="text-[10px] font-normal uppercase tracking-[0.16em] text-muted-foreground/75 sm:text-xs">
         stat updated monthly


### PR DESCRIPTION
## Summary
- removed the duplicate `aria-label` attribute on `components/home/HeroMonthlyLeadsPill.tsx`
- removed the duplicate rendered leads text line in the same component
- preserved the existing copy variant (`last month`) so JSX is valid and TypeScript build passes

## Validation
- ran `pnpm run build` successfully after the change

## Notes
- build still emits pre-existing warnings about `Link legacyBehavior` server-component children and missing Supabase env vars; these warnings did not block the build in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b8ac76c8c83219dbbe2d7a9b4760c)