### PR TITLE
Point homepage hero CTA pill to get-started flow

### DIFF
--- a/components/home/HeroMonthlyLeadsPill.tsx
+++ b/components/home/HeroMonthlyLeadsPill.tsx
@@ -16,8 +16,8 @@ export default function HeroMonthlyLeadsPill({ className }: HeroMonthlyLeadsPill
 
   return (
     <Link
-      href="/case-studies"
-      aria-label={`View case studies: ${leadsText} leads delivered to clients last month. Stat updated monthly.`}
+      href="/get-started"
+      aria-label={`Get started with Prism: ${leadsText} leads delivered to clients last month. Stat updated monthly.`}
       className={cn(
         "group relative inline-flex w-fit max-w-[25rem] flex-col items-center justify-center gap-1 rounded-[1.5rem] border border-border/60 bg-background/80 px-4 py-3 text-center text-xs text-muted-foreground shadow-[0_18px_50px_-32px_rgba(0,0,0,0.45)] backdrop-blur-sm transition-[transform,box-shadow,border-color,background-color] duration-200 ease-out hover:-translate-y-0.5 hover:border-border/80 hover:bg-background/90 hover:shadow-[0_26px_60px_-34px_rgba(0,0,0,0.55)] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:px-6 sm:py-3.5 sm:text-sm",
         className,
@@ -29,7 +29,7 @@ export default function HeroMonthlyLeadsPill({ className }: HeroMonthlyLeadsPill
       <span className="text-[10px] font-normal uppercase tracking-[0.16em] text-muted-foreground/75 sm:text-xs">
         stat updated monthly
       </span>
-      <span className="sr-only">View case studies</span>
+      <span className="sr-only">Get started with Prism</span>
       <ArrowUpRight
         aria-hidden="true"
         className="absolute right-3 top-3 h-4 w-4 opacity-45 transition-opacity group-hover:opacity-80"


### PR DESCRIPTION
## Summary
- Updated the homepage hero leads pill link target from `/case-studies` to `/get-started`
- Updated the pill's `aria-label` copy to reflect the get-started destination
- Updated the screen-reader-only text to match the new CTA intent

## Validation
- Verified the component diff in `components/home/HeroMonthlyLeadsPill.tsx`
- Captured a homepage screenshot after the change

## Notes
- While previewing locally, some remote image fetches returned `ENETUNREACH` in dev logs, but this does not affect the CTA route update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b8fd5c3dc8321954e84f0d2ad3c09)