### PR TITLE
Shrink software card icons on home and software pages

### DIFF
--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -366,7 +366,7 @@ export default function ClientPage() {
                       alt={app.icon.alt}
                       size={app.icon.size}
                       aria-hidden="true"
-                      className="opacity-95"
+                      className="h-8 w-8 opacity-95"
                     />
                     <CardTitle className="text-xl">{app.title}</CardTitle>
                     <CardDescription className="text-sm text-muted-foreground">

--- a/app/software/page.tsx
+++ b/app/software/page.tsx
@@ -70,7 +70,7 @@ export default function SoftwarePage() {
                       alt={app.icon.alt}
                       size={app.icon.size}
                       aria-hidden="true"
-                      className="opacity-95"
+                      className="h-8 w-8 opacity-95"
                     />
                     <CardTitle className="text-xl">{app.title}</CardTitle>
                     <CardDescription className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- reduced the displayed app icon size inside software cards by adding explicit `h-8 w-8` sizing to `PixelishIcon` instances
- applied the same update in both places where the Prism app cards render:
  - homepage (`app/client-page.tsx`)
  - `/software` page (`app/software/page.tsx`)

## Validation
- started the Next.js dev server and captured updated screenshots for both routes

## Screenshots
- Homepage: `browser:/tmp/codex_browser_invocations/e1166aa747276675/artifacts/artifacts/home-icons-small.png`
- Software page: `browser:/tmp/codex_browser_invocations/e1166aa747276675/artifacts/artifacts/software-icons-small.png`

## Notes
- while loading the pages in dev, unrelated external image fetches returned 500/ENETUNREACH in this environment; local route rendering still succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b91f7aab88321bef89a300d34aed8)