### PR TITLE
Shrink software app icons by 10x on home and software pages

### DIFF
--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -366,7 +366,7 @@ export default function ClientPage() {
                       alt={app.icon.alt}
                       size={app.icon.size}
                       aria-hidden="true"
-                      className="h-8 w-8 opacity-95"
+                      className="h-8 w-8 origin-top-left scale-[0.1] opacity-95"
                     />
                     <CardTitle className="text-xl">{app.title}</CardTitle>
                     <CardDescription className="text-sm text-muted-foreground">

--- a/app/software/page.tsx
+++ b/app/software/page.tsx
@@ -70,7 +70,7 @@ export default function SoftwarePage() {
                       alt={app.icon.alt}
                       size={app.icon.size}
                       aria-hidden="true"
-                      className="h-8 w-8 opacity-95"
+                      className="h-8 w-8 origin-top-left scale-[0.1] opacity-95"
                     />
                     <CardTitle className="text-xl">{app.title}</CardTitle>
                     <CardDescription className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- reduced the software card icon visual size by 10x where Prism apps are rendered
- applied the same icon scaling class update in both places that render `PRISM_APPS`:
  - `app/client-page.tsx` (home page apps section)
  - `app/software/page.tsx` (`/software` cards)
- kept the change scoped to these software icons only so other Pixelish icons across the site are unaffected

## Why this fixes the issue
- these sections forced each app icon to `h-8 w-8`, which made the icons display much larger than intended
- adding `scale-[0.1]` (with `origin-top-left`) makes each icon render at one-tenth of that visual size, matching the request for "about ten times smaller"

## Validation
- ran the app locally and captured updated screenshots for both impacted pages
  - `/software`
  - `/` (home)

## Notes
- this is intentionally a targeted UI fix for the three software app icons (Density, Hot Content, Engineering Tracker) in their card components only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b98bd7fb8832191e272791b39b2d5)