### PR TITLE
Redesign software app cards for homepage and software page

### DIFF
--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -18,6 +18,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion"
 import { Badge } from "@/components/ui/badge"
+import SoftwareAppCards from "@/components/software/SoftwareAppCards"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -354,39 +355,11 @@ export default function ClientPage() {
                 </p>
               </div>
             </div>
-            <div className="grid gap-6 md:grid-cols-2">
-              {PRISM_APPS.map((app) => (
-                <Card
-                  key={app.title}
-                  className="flex h-full flex-col border-border/60 bg-card/90 transition-transform duration-200 ease-out hover:-translate-y-1 hover:shadow-lg"
-                >
-                  <CardHeader className="space-y-3">
-                    <PixelishIcon
-                      src={app.icon.src}
-                      alt={app.icon.alt}
-                      size={app.icon.size}
-                      aria-hidden="true"
-                      className="h-8 w-8 origin-top-left scale-[0.1] opacity-95"
-                    />
-                    <CardTitle className="text-xl">{app.title}</CardTitle>
-                    <CardDescription className="text-sm text-muted-foreground">
-                      {app.description}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardFooter className="mt-auto">
-                    <Button
-                      asChild
-                      variant="outline"
-                      className="w-full rounded-full transition-transform duration-200 ease-out hover:-translate-y-0.5 hover:shadow-lg active:translate-y-0"
-                    >
-                      <Link href={app.href} target="_blank" rel="noopener noreferrer">
-                        {app.hrefLabel}
-                      </Link>
-                    </Button>
-                  </CardFooter>
-                </Card>
-              ))}
-            </div>
+            <SoftwareAppCards
+              apps={PRISM_APPS}
+              cardClassName="bg-card/90"
+              buttonClassName="rounded-full"
+            />
           </div>
         </section>
 

--- a/app/software/page.tsx
+++ b/app/software/page.tsx
@@ -1,19 +1,9 @@
 import type { Metadata } from "next"
-import Link from "next/link"
-
-import PixelishIcon from "@/components/pixelish/PixelishIcon"
 import Footer from "@/components/footer"
 import Navbar from "@/components/navbar"
 import { ItemListSchema } from "@/components/schema-markup"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+import SoftwareAppCards from "@/components/software/SoftwareAppCards"
 import { PRISM_APPS } from "@/lib/software-apps"
 
 export const metadata: Metadata = {
@@ -58,39 +48,11 @@ export default function SoftwarePage() {
 
         <section className="py-12 sm:py-16 bg-muted/20">
           <div className="container mx-auto px-4 sm:px-6">
-            <div className="grid gap-6 md:grid-cols-2">
-              {PRISM_APPS.map((app) => (
-                <Card
-                  key={app.title}
-                  className="flex h-full flex-col border-border/60 bg-card/30 backdrop-blur-sm transition-[transform,background-color] duration-200 ease-out hover:-translate-y-1 hover:bg-card/45"
-                >
-                  <CardHeader className="space-y-3">
-                    <PixelishIcon
-                      src={app.icon.src}
-                      alt={app.icon.alt}
-                      size={app.icon.size}
-                      aria-hidden="true"
-                      className="h-8 w-8 origin-top-left scale-[0.1] opacity-95"
-                    />
-                    <CardTitle className="text-xl">{app.title}</CardTitle>
-                    <CardDescription className="text-sm text-muted-foreground">
-                      {app.description}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardFooter className="mt-auto">
-                    <Button
-                      asChild
-                      variant="outline"
-                      className="w-full rounded-md transition-transform duration-200 ease-out hover:-translate-y-0.5 hover:shadow-lg active:translate-y-0"
-                    >
-                      <Link href={app.href} target="_blank" rel="noopener noreferrer">
-                        {app.hrefLabel}
-                      </Link>
-                    </Button>
-                  </CardFooter>
-                </Card>
-              ))}
-            </div>
+            <SoftwareAppCards
+              apps={PRISM_APPS}
+              cardClassName="bg-card/35 backdrop-blur-sm"
+              buttonClassName="rounded-lg"
+            />
           </div>
         </section>
       </main>

--- a/components/software/SoftwareAppCards.tsx
+++ b/components/software/SoftwareAppCards.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link"
+
+import PixelishIcon from "@/components/pixelish/PixelishIcon"
+import { Button } from "@/components/ui/button"
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import type { SoftwareApp } from "@/lib/software-apps"
+
+type SoftwareAppCardsProps = {
+  apps: SoftwareApp[]
+  cardClassName?: string
+  buttonClassName?: string
+}
+
+export default function SoftwareAppCards({
+  apps,
+  cardClassName = "",
+  buttonClassName = "",
+}: SoftwareAppCardsProps) {
+  return (
+    <div className="grid gap-6 md:grid-cols-2 xl:gap-7">
+      {apps.map((app) => (
+        <Card
+          key={app.title}
+          className={`group relative overflow-hidden border-border/60 bg-card/90 transition-[transform,box-shadow,border-color] duration-300 ease-out hover:-translate-y-1 hover:border-primary/30 hover:shadow-xl ${cardClassName}`}
+        >
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(100%_100%_at_0%_0%,hsl(var(--primary)/0.14)_0%,transparent_55%)] opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+          <CardHeader className="relative z-10 space-y-5 pb-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="relative flex h-14 w-14 items-center justify-center rounded-2xl border border-border/80 bg-background/95 shadow-sm ring-1 ring-border/50">
+                <div className="absolute inset-1 rounded-xl border border-border/50 bg-muted/30" />
+                <PixelishIcon
+                  src={app.icon.src}
+                  alt={app.icon.alt}
+                  size={app.icon.size}
+                  aria-hidden="true"
+                  className="relative h-10 w-10 origin-center scale-[0.1] opacity-95"
+                />
+              </div>
+              <div className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/85 px-3 py-1 text-[11px] font-medium tracking-wide text-muted-foreground">
+                <span className="h-1.5 w-1.5 rounded-full bg-primary/80" aria-hidden="true" />
+                {app.platform ?? "Prism app"}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <CardTitle className="text-2xl tracking-tight text-foreground">{app.title}</CardTitle>
+              <CardDescription className="max-w-[48ch] text-base leading-relaxed text-muted-foreground">
+                {app.description}
+              </CardDescription>
+            </div>
+          </CardHeader>
+          <CardFooter className="relative z-10 mt-auto pt-2">
+            <Button
+              asChild
+              variant="outline"
+              className={`w-full justify-between rounded-xl border-border/70 bg-background/80 px-4 text-sm font-medium transition-all duration-300 group-hover:border-primary/40 group-hover:bg-background ${buttonClassName}`}
+            >
+              <Link href={app.href} target="_blank" rel="noopener noreferrer">
+                <span>{app.hrefLabel}</span>
+                <span aria-hidden="true">↗</span>
+              </Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/docs/pages-overview.md
+++ b/docs/pages-overview.md
@@ -34,7 +34,8 @@ Quick reference for the pages we edit most often.
 
 ## Software (`app/software/page.tsx`)
 - Growth tools hub listing Prism-built software (currently Density, Hot Content, and Engineering Tracker).
-- App card data is shared via `lib/software-apps.ts` (including Lordicon animation config for the card icons); update this list to keep the homepage section and `/software` in sync.
+- App card data is shared via `lib/software-apps.ts`; update this list to keep the homepage section and `/software` in sync.
+- The homepage + `/software` cards are rendered by `components/software/SoftwareAppCards.tsx`, including the framed icon treatment sized for small pixel icons.
 
 ## Podcast (`app/podcast/page.tsx`)
 - Podcast hub + recent episode preview cards.


### PR DESCRIPTION
## Summary
- redesigned the software app sections on both the homepage (`app/client-page.tsx`) and `/software` (`app/software/page.tsx`) to better fit the smaller pixel icon assets
- extracted a shared `SoftwareAppCards` component (`components/software/SoftwareAppCards.tsx`) so both pages stay visually consistent
- introduced a new framed icon treatment, stronger card hierarchy, platform pill, and updated CTA row styling for each app card
- updated `docs/pages-overview.md` to document where this shared software card layout now lives

## Validation
- `pnpm lint` passed
- captured updated UI screenshots for both affected surfaces

## Screenshots
- Homepage software section: `browser:/tmp/codex_browser_invocations/f0779ab93da731a3/artifacts/artifacts/home-software-section-v2.png`
- /software page section: `browser:/tmp/codex_browser_invocations/820cff1454c2f0b8/artifacts/artifacts/software-page-redesign.png`

## Rollout notes
- no migrations or feature flags required

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9b93018083218dc652942a3fcd0c)