### PR TITLE
Refine hero monthly leads pill layout on mobile

### DIFF
--- a/__tests__/hero-monthly-leads-pill.test.tsx
+++ b/__tests__/hero-monthly-leads-pill.test.tsx
@@ -17,18 +17,16 @@ jest.mock("next/link", () => ({
 }))
 
 describe("HeroMonthlyLeadsPill", () => {
-  it("renders a link to /case-studies with simplified monthly stat copy", () => {
+  it("renders a link to /get-started with monthly stat copy", () => {
     render(<HeroMonthlyLeadsPill />)
 
     const link = screen.getByRole("link")
-    expect(link).toHaveAttribute("href", "/case-studies")
+    expect(link).toHaveAttribute("href", "/get-started")
 
     const latest = HOME_HERO_MONTHLY_LEADS_STATS[0]
     expect(latest).toBeTruthy()
 
     expect(link).toHaveTextContent(`${latest.leads.toLocaleString("en-US")} leads delivered to clients last month 🥳`)
-    expect(link).toHaveTextContent(`${latest.leads.toLocaleString("en-US")} leads delivered to clients in last month 🥳`)
     expect(link).toHaveTextContent("stat updated monthly")
   })
 })
-

--- a/components/home/HeroMonthlyLeadsPill.tsx
+++ b/components/home/HeroMonthlyLeadsPill.tsx
@@ -19,20 +19,20 @@ export default function HeroMonthlyLeadsPill({ className }: HeroMonthlyLeadsPill
       href="/get-started"
       aria-label={`Get started with Prism: ${leadsText} leads delivered to clients last month. Stat updated monthly.`}
       className={cn(
-        "group relative inline-flex w-fit max-w-[25rem] flex-col items-center justify-center gap-1 rounded-[1.5rem] border border-border/60 bg-background/80 px-4 py-3 text-center text-xs text-muted-foreground shadow-[0_18px_50px_-32px_rgba(0,0,0,0.45)] backdrop-blur-sm transition-[transform,box-shadow,border-color,background-color] duration-200 ease-out hover:-translate-y-0.5 hover:border-border/80 hover:bg-background/90 hover:shadow-[0_26px_60px_-34px_rgba(0,0,0,0.55)] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:px-6 sm:py-3.5 sm:text-sm",
+        "group relative inline-flex w-fit max-w-[min(25rem,calc(100vw-2rem))] flex-col items-center justify-center gap-1.5 rounded-[1.5rem] border border-border/60 bg-background/80 px-4 py-3.5 text-center text-xs text-muted-foreground shadow-[0_18px_50px_-32px_rgba(0,0,0,0.45)] backdrop-blur-sm transition-[transform,box-shadow,border-color,background-color] duration-200 ease-out hover:-translate-y-0.5 hover:border-border/80 hover:bg-background/90 hover:shadow-[0_26px_60px_-34px_rgba(0,0,0,0.55)] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:gap-1 sm:px-6 sm:py-3.5 sm:text-sm",
         className,
       )}
     >
-      <span className="max-w-[20rem] font-semibold leading-snug text-foreground sm:max-w-none">
+      <span className="max-w-[18.5rem] text-balance pr-0 font-semibold leading-snug text-foreground sm:max-w-none sm:pr-5">
         {leadsText} leads delivered to clients last month 🥳
       </span>
-      <span className="text-[10px] font-normal uppercase tracking-[0.16em] text-muted-foreground/75 sm:text-xs">
+      <span className="text-[10px] font-normal uppercase tracking-[0.14em] text-muted-foreground/75 sm:text-xs sm:tracking-[0.16em]">
         stat updated monthly
       </span>
       <span className="sr-only">Get started with Prism</span>
       <ArrowUpRight
         aria-hidden="true"
-        className="absolute right-3 top-3 h-4 w-4 opacity-45 transition-opacity group-hover:opacity-80"
+        className="absolute right-3 top-3 hidden h-4 w-4 opacity-45 transition-opacity group-hover:opacity-80 sm:block"
       />
       <span aria-hidden="true" className="pointer-events-none absolute inset-0 rounded-[1.5rem] ring-1 ring-inset ring-white/5" />
     </Link>


### PR DESCRIPTION
## Summary
- tighten the hero monthly leads pill mobile sizing with a viewport-aware max width to prevent awkward edge crowding
- improve mobile text rhythm by slightly increasing inter-line spacing, balancing headline wrapping, and reducing uppercase tracking on the secondary label
- hide the top-right arrow icon on small screens so the headline can center cleanly, while preserving the icon on `sm+`
- align/update the existing unit test assertions to match the current `/get-started` destination and canonical copy

## Testing
- `pnpm test -- hero-monthly-leads-pill.test.tsx`

## Notes
- Attempted to generate a mobile screenshot via Playwright, but the browser container Chromium process crashed with `SIGSEGV` during launch in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9e7b4df0832188b2084bde3e37e5)