### PR TITLE
Simplify hero monthly leads pill copy

### DIFF
--- a/components/home/HeroMonthlyLeadsPill.tsx
+++ b/components/home/HeroMonthlyLeadsPill.tsx
@@ -17,17 +17,14 @@ export default function HeroMonthlyLeadsPill({ className }: HeroMonthlyLeadsPill
   return (
     <Link
       href="/get-started"
-      aria-label={`Get started with Prism: ${leadsText} leads delivered to clients last month. Stat updated monthly.`}
+      aria-label={`Get started with Prism: ${leadsText} leads delivered to clients last month.`}
       className={cn(
         "group relative inline-flex w-fit max-w-[min(25rem,calc(100vw-2rem))] flex-col items-center justify-center gap-1.5 rounded-[1.5rem] border border-border/60 bg-background/80 px-4 py-3.5 text-center text-xs text-muted-foreground shadow-[0_18px_50px_-32px_rgba(0,0,0,0.45)] backdrop-blur-sm transition-[transform,box-shadow,border-color,background-color] duration-200 ease-out hover:-translate-y-0.5 hover:border-border/80 hover:bg-background/90 hover:shadow-[0_26px_60px_-34px_rgba(0,0,0,0.55)] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:gap-1 sm:px-6 sm:py-3.5 sm:text-sm",
         className,
       )}
     >
       <span className="max-w-[18.5rem] text-balance pr-0 font-semibold leading-snug text-foreground sm:max-w-none sm:pr-5">
-        {leadsText} leads delivered to clients last month 🥳
-      </span>
-      <span className="text-[10px] font-normal uppercase tracking-[0.14em] text-muted-foreground/75 sm:text-xs sm:tracking-[0.16em]">
-        stat updated monthly
+        {leadsText} leads delivered to clients last month
       </span>
       <span className="sr-only">Get started with Prism</span>
       <ArrowUpRight


### PR DESCRIPTION
## Summary
- removed the redundant `stat updated monthly` line from the home hero monthly leads pill
- removed the celebratory emoji from the primary leads text for a cleaner presentation
- updated the link `aria-label` so accessibility copy matches the visible text

## Validation
- Ran `pnpm install` to restore dependencies needed for local preview
- Launched `pnpm dev` and captured an updated screenshot of the home page hero pill

## Screenshot
![Updated hero monthly leads pill](browser:/tmp/codex_browser_invocations/65031e43d0662dd1/artifacts/artifacts/home-pill-cleaned.png)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba620b3ec8321a86d55aa360921ad)