### PR TITLE
Fix software app icon scaling

### DIFF
--- a/components/software/SoftwareAppCards.tsx
+++ b/components/software/SoftwareAppCards.tsx
@@ -33,7 +33,7 @@ export default function SoftwareAppCards({
                   alt={app.icon.alt}
                   size={app.icon.size}
                   aria-hidden="true"
-                  className="relative h-10 w-10 origin-center scale-[0.1] opacity-95"
+                  className="relative h-10 w-10 origin-center opacity-95"
                 />
               </div>
               <div className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/85 px-3 py-1 text-[11px] font-medium tracking-wide text-muted-foreground">


### PR DESCRIPTION
## Summary
- remove the accidental `scale-[0.1]` utility from software app card icons
- keep the icon frame sizing intact so each app icon renders visibly at the intended 40x40 visual size

## Validation
- ran `pnpm dev` and verified `/software` renders with visible icons for each software card
- captured updated UI screenshot: `browser:/tmp/codex_browser_invocations/624b0d43730ff0da/artifacts/artifacts/software-icons-fixed.png`

## Notes
- while loading `/software`, Next.js printed existing warnings about `prism-logo.jpeg` quality/placeholder and `allowedDevOrigins`; these are unrelated to this icon scaling fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bafa33dd4832196ea164423dd6b9e)