### PR TITLE
Improve blog readability with Inter typography system

### DIFF
--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -1,0 +1,12 @@
+import { Inter } from "next/font/google"
+import type React from "react"
+
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+})
+
+export default function BlogLayout({ children }: { children: React.ReactNode }) {
+  return <div className={`blog-reading-surface ${inter.className}`}>{children}</div>
+}
+

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -90,7 +90,7 @@ export default async function Blog({
   }))
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="blog-reading-surface flex min-h-screen flex-col">
       <Navbar />
       <main className="relative flex-1">
         <div className="container mx-auto px-4 md:px-6">
@@ -99,10 +99,10 @@ export default async function Blog({
 
         <section className="border-b border-border/60 py-10 md:py-14">
           <div className="container mx-auto px-4 md:px-6">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.32em] text-muted-foreground font-pixel">prism blog</p>
-            <h1 className="mt-4 text-4xl font-semibold sm:text-5xl md:text-6xl">insights & ideas</h1>
-            <p className="mt-4 text-muted-foreground">
-              thoughts on design, development, and digital strategy from the prism team
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">prism blog</p>
+            <h1 className="blog-display-title mt-4 text-foreground">Insights & ideas</h1>
+            <p className="blog-hero-subtitle mt-4 text-muted-foreground">
+              Thoughtful breakdowns on design, development, and digital strategy from the Prism team.
             </p>
           </div>
         </section>
@@ -142,8 +142,8 @@ export default async function Blog({
         <section className="border-t border-border/60 bg-card/15 py-12 md:py-16">
           <div className="container mx-auto px-4 md:px-6">
             <div className="mx-auto max-w-2xl space-y-4 text-center">
-              <h2 className="text-2xl font-semibold sm:text-3xl">want to work with us?</h2>
-              <p className="text-muted-foreground">let's discuss how we can help your business grow</p>
+              <h2 className="text-2xl font-semibold sm:text-3xl">Want to work with us?</h2>
+              <p className="text-muted-foreground">Let's discuss how we can help your business grow.</p>
               <div className="pt-4">
                 <BlogCTAButtonLazy />
               </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1609,55 +1609,98 @@ input, textarea, select {
 }
 
 /* Blog Typography Improvements */
-.prose-blog {
-  @apply prose prose-neutral dark:prose-invert lg:prose-lg max-w-none;
-  
-  /* Base font improvements */
-  font-size: 1.125rem; /* 18px base for better readability */
+.blog-reading-surface {
+  font-family: Inter, var(--font-sans), -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.blog-reading-surface .blog-display-title {
+  font-size: clamp(2.1rem, 4.6vw, 3.6rem);
+  line-height: 1.12;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  max-width: 20ch;
+}
+
+.blog-reading-surface .blog-hero-subtitle {
+  font-size: clamp(1.06rem, 1rem + 0.24vw, 1.2rem);
   line-height: 1.75;
-  color: rgb(17 17 17); /* Darker for better contrast */
+  max-width: 66ch;
+}
+
+.blog-reading-surface .blog-post-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.12;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.blog-reading-surface .blog-post-lead {
+  font-size: clamp(1.1rem, 1.04rem + 0.3vw, 1.3rem);
+  line-height: 1.7;
+  color: hsl(var(--muted-foreground));
+}
+
+.blog-reading-surface .blog-card-title {
+  font-size: clamp(1.2rem, 1.08rem + 0.25vw, 1.35rem);
+  line-height: 1.4;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.blog-reading-surface .blog-card-description {
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.prose-blog {
+  @apply prose prose-neutral dark:prose-invert max-w-none;
+  font-size: clamp(1.06rem, 0.98rem + 0.24vw, 1.2rem);
+  line-height: 1.85;
+  letter-spacing: 0.003em;
+  color: rgb(20 20 20);
 }
 
 .dark .prose-blog {
-  color: rgb(245 245 245);
+  color: rgb(240 240 240);
 }
 
-/* Paragraph spacing */
 .prose-blog p {
-  @apply mb-6 leading-relaxed;
-  color: rgb(17 17 17); /* Ensure consistent contrast for paragraphs */
+  @apply mb-7;
+  line-height: 1.85;
+  color: inherit;
 }
 
-.dark .prose-blog p {
-  color: rgb(245 245 245);
-}
-
-/* Headings styling */
 .prose-blog h1,
 .prose-blog h2,
 .prose-blog h3,
 .prose-blog h4,
 .prose-blog h5,
 .prose-blog h6 {
-  @apply font-bold tracking-tight;
-  margin-top: 3rem;
-  margin-bottom: 1.5rem;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+  line-height: 1.25;
+  color: hsl(var(--foreground));
+  margin-top: 3.2rem;
+  margin-bottom: 1.25rem;
 }
 
 .prose-blog h1 {
-  @apply text-3xl md:text-4xl;
+  font-size: clamp(2rem, 3.1vw, 2.7rem);
 }
 
 .prose-blog h2 {
-  @apply text-2xl md:text-3xl;
+  font-size: clamp(1.6rem, 2.5vw, 2.2rem);
 }
 
 .prose-blog h3 {
-  @apply text-xl md:text-2xl;
+  font-size: clamp(1.35rem, 2vw, 1.8rem);
 }
 
 .prose-blog h4 {
-  @apply text-lg md:text-xl;
+  font-size: clamp(1.15rem, 1.4vw, 1.35rem);
 }
 
 .prose-blog h2,
@@ -1666,74 +1709,58 @@ input, textarea, select {
   scroll-margin-top: 120px;
 }
 
-/* First heading after article start */
 .prose-blog > h1:first-child,
 .prose-blog > h2:first-child,
 .prose-blog > h3:first-child {
   margin-top: 0;
 }
 
-/* Lists improvements */
 .prose-blog ul,
 .prose-blog ol {
-  @apply my-6 space-y-3;
-  padding-left: 1.5rem;
+  @apply my-7;
+  padding-left: 1.4rem;
   list-style-position: outside;
 }
 
-.prose-blog ul {
-  list-style-type: disc;
-}
-
-.prose-blog ol {
-  list-style-type: decimal;
-}
+.prose-blog ul { list-style-type: disc; }
+.prose-blog ol { list-style-type: decimal; }
 
 .prose-blog li {
-  @apply leading-relaxed;
-  padding-left: 0.375rem;
+  margin-bottom: 0.7rem;
+  line-height: 1.8;
+  padding-left: 0.3rem;
 }
 
-.prose-blog li::marker {
-  color: rgb(75 75 75); /* Darker for better contrast */
-}
+.prose-blog li::marker { color: rgb(92 92 92); }
+.dark .prose-blog li::marker { color: rgb(156 156 156); }
 
 .prose-blog ol li::marker {
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
 
-.dark .prose-blog li::marker {
-  color: rgb(163 163 163);
-}
-
-/* Nested lists */
 .prose-blog li ul,
 .prose-blog li ol {
-  margin-top: 0.75rem;
-  margin-bottom: 0.75rem;
+  margin-top: 0.8rem;
+  margin-bottom: 0.8rem;
 }
 
-/* Links styling */
 .prose-blog a:not(.mdx-cta) {
-  @apply text-neutral-900 dark:text-neutral-100 underline decoration-neutral-500 dark:decoration-neutral-500 underline-offset-2 transition-colors;
+  @apply text-neutral-900 dark:text-neutral-100 underline decoration-neutral-500 dark:decoration-neutral-400 underline-offset-2 transition-colors;
 }
 
 .prose-blog a:not(.mdx-cta):hover {
-  @apply decoration-neutral-700 dark:decoration-neutral-300;
+  @apply decoration-neutral-700 dark:decoration-neutral-200;
 }
 
-.prose-blog a.mdx-cta {
-  text-decoration: none;
-}
+.prose-blog a.mdx-cta { text-decoration: none; }
 
-/* Blockquotes */
 .prose-blog blockquote {
-  @apply border-l-4 border-neutral-300 dark:border-neutral-700 pl-6 py-1 my-8 italic;
+  @apply border-l-4 border-neutral-300 dark:border-neutral-700 pl-6 py-1 my-9 italic;
+  color: hsl(var(--muted-foreground));
   quotes: none;
 }
 
-/* Code blocks */
 .prose-blog code {
   @apply bg-neutral-100 dark:bg-neutral-800 px-1.5 py-0.5 rounded text-sm font-mono text-neutral-900 dark:text-neutral-100;
 }
@@ -1742,11 +1769,8 @@ input, textarea, select {
   @apply bg-neutral-100 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 rounded-lg p-4 overflow-x-auto my-8;
 }
 
-.prose-blog pre code {
-  @apply bg-transparent p-0 text-inherit;
-}
+.prose-blog pre code { @apply bg-transparent p-0 text-inherit; }
 
-/* Horizontal rules */
 .prose-blog hr {
   @apply my-12 border-0;
   height: 1px;
@@ -1757,105 +1781,71 @@ input, textarea, select {
   background: linear-gradient(90deg, transparent, rgba(245, 245, 245, 0.25), transparent);
 }
 
-/* Images */
-.prose-blog img {
-  @apply rounded-lg my-8;
-}
+.prose-blog img { @apply rounded-lg my-8; }
+.prose-blog table { @apply w-full my-8; }
+.prose-blog th { @apply text-left font-semibold p-3 border-b-2 border-neutral-300 dark:border-neutral-700; }
+.prose-blog td { @apply p-3 border-b border-neutral-200 dark:border-neutral-800; }
+.prose-blog strong { @apply font-semibold text-neutral-900 dark:text-neutral-100; }
 
-/* Tables */
-.prose-blog table {
-  @apply w-full my-8;
-}
+.prose-blog > *:first-child { margin-top: 0; }
+.prose-blog > *:last-child { margin-bottom: 0; }
 
-.prose-blog th {
-  @apply text-left font-semibold p-3 border-b-2 border-neutral-300 dark:border-neutral-700;
-}
+.prose-blog .blog-cta { @apply my-12 p-8 bg-neutral-50 dark:bg-neutral-900 rounded-xl; }
 
-.prose-blog td {
-  @apply p-3 border-b border-neutral-200 dark:border-neutral-800;
-}
+.enhanced-readability p { @apply text-lg leading-loose mb-8; }
+.enhanced-readability blockquote { @apply text-lg italic text-neutral-600 dark:text-neutral-400 border-l-8 border-neutral-300 dark:border-neutral-700 pl-8 my-12; }
 
-/* Strong emphasis */
-.prose-blog strong {
-  @apply font-semibold text-neutral-900 dark:text-neutral-100;
-}
-
-/* Improve spacing for blog post sections */
-.prose-blog > *:first-child {
-  margin-top: 0;
-}
-
-.prose-blog > *:last-child {
-  margin-bottom: 0;
-}
-
-/* CTA sections within blog posts */
-.prose-blog .blog-cta {
-  @apply my-12 p-8 bg-neutral-50 dark:bg-neutral-900 rounded-xl;
-}
-
-/* Enhanced readability for specific posts */
-.enhanced-readability p {
-  @apply text-lg leading-loose mb-8;
-}
-
-.enhanced-readability blockquote {
-  @apply text-lg italic text-neutral-600 dark:text-neutral-400 border-l-8 border-neutral-300 dark:border-neutral-700 pl-8 my-12;
-}
-
-/* Mobile-specific blog improvements */
 @media (max-width: 640px) {
   .prose-blog {
-    font-size: 1rem; /* 16px on mobile for better readability */
-    line-height: 1.65;
-  }
-  
-  .prose-blog p {
-    margin-bottom: 1.5rem;
-    line-height: 1.7;
-  }
-  
-  .prose-blog h1,
-  .prose-blog h2,
-  .prose-blog h3 {
-    margin-top: 2rem;
-    margin-bottom: 1rem;
-    line-height: 1.3;
-  }
-  
-  .prose-blog ul,
-  .prose-blog ol {
-    margin: 1.5rem 0;
-    padding-left: 1.25rem;
-  }
-  
-  .prose-blog li {
-    margin-bottom: 0.5rem;
-  }
-}
-
-/* Tablet readability pass */
-@media (min-width: 640px) and (max-width: 1024px) {
-  .prose-blog {
-    font-size: 1.0625rem; /* 17px on tablets */
+    font-size: 1rem;
     line-height: 1.75;
   }
 
   .prose-blog p {
-    margin-bottom: 1.75rem;
+    margin-bottom: 1.4rem;
+    line-height: 1.78;
   }
 
   .prose-blog h1,
   .prose-blog h2,
   .prose-blog h3 {
-    margin-top: 2.5rem;
-    margin-bottom: 1.25rem;
+    margin-top: 2.1rem;
+    margin-bottom: 0.95rem;
+    line-height: 1.28;
   }
 
   .prose-blog ul,
   .prose-blog ol {
-    margin: 1.75rem 0;
-    padding-left: 1.5rem;
+    margin: 1.4rem 0;
+    padding-left: 1.2rem;
+  }
+
+  .prose-blog li {
+    margin-bottom: 0.45rem;
+  }
+}
+
+@media (min-width: 640px) and (max-width: 1024px) {
+  .prose-blog {
+    font-size: 1.075rem;
+    line-height: 1.82;
+  }
+
+  .prose-blog p {
+    margin-bottom: 1.65rem;
+  }
+
+  .prose-blog h1,
+  .prose-blog h2,
+  .prose-blog h3 {
+    margin-top: 2.6rem;
+    margin-bottom: 1.1rem;
+  }
+
+  .prose-blog ul,
+  .prose-blog ol {
+    margin: 1.6rem 0;
+    padding-left: 1.45rem;
   }
 }
 

--- a/components/blog-email-signup.tsx
+++ b/components/blog-email-signup.tsx
@@ -49,10 +49,10 @@ export default function BlogEmailSignup() {
       <Card className="mx-auto max-w-3xl rounded-md bg-card/40 shadow-none backdrop-blur-sm transition hover:bg-card/55">
         <CardContent className="flex flex-col gap-6 p-6 sm:p-8 md:flex-row md:items-center md:justify-between">
           <div className="space-y-2 md:max-w-sm">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.32em] text-muted-foreground font-pixel">stay in the loop</p>
-            <h2 className="text-xl font-semibold text-foreground sm:text-2xl">get fresh prism notes via email</h2>
-            <p className="text-sm leading-relaxed text-muted-foreground">
-              when we publish new experiments or playbooks, we’ll send you the highlights so you can apply them faster.
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">stay in the loop</p>
+            <h2 className="text-2xl font-semibold text-foreground">Get fresh Prism notes via email</h2>
+            <p className="text-base leading-7 text-muted-foreground">
+              When we publish new experiments or playbooks, we’ll send you the highlights so you can apply them faster.
             </p>
           </div>
           <form onSubmit={handleSubmit} className="flex w-full flex-col gap-3 md:max-w-sm">

--- a/components/blog-filter-navigation-server.tsx
+++ b/components/blog-filter-navigation-server.tsx
@@ -73,7 +73,7 @@ export default function BlogFilterNavigationServer({
               placeholder="Search posts…"
               aria-label="Search posts"
               autoComplete="off"
-              className="h-auto w-full rounded-md border border-border/60 bg-card/30 py-2.5 pl-10 pr-10 text-sm transition-colors duration-200 focus:bg-card focus-visible:ring-ring"
+              className="h-auto w-full rounded-md border border-border/60 bg-card/30 py-3 pl-10 pr-10 text-base leading-6 transition-colors duration-200 focus:bg-card focus-visible:ring-ring"
             />
             <button type="submit" className="sr-only">
               Search
@@ -106,7 +106,7 @@ export default function BlogFilterNavigationServer({
                     href={buildBlogUrl({ category: slug, query: normalizedQuery })}
                     prefetch={false}
                     className={cn(
-                      "shrink-0 rounded-md border border-border/60 bg-muted/40 px-4 py-2 text-[10px] font-semibold uppercase font-pixel tracking-[0.16em] text-muted-foreground transition-colors duration-200 hover:bg-muted/60 hover:text-foreground",
+                      "shrink-0 rounded-md border border-border/60 bg-muted/40 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground transition-colors duration-200 hover:bg-muted/60 hover:text-foreground",
                       isActive && "border-primary bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground",
                     )}
                     aria-current={isActive ? "true" : undefined}

--- a/components/blog-post-layout.tsx
+++ b/components/blog-post-layout.tsx
@@ -113,11 +113,11 @@ export default function BlogPostLayout({
                       slug={slug}
                     />
                     <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-muted-foreground sm:text-sm">
-                      <span className="inline-block rounded-md border border-border/60 bg-muted/30 px-3 py-1 text-[10px] font-semibold uppercase font-pixel tracking-[0.16em] text-foreground/90">
+                      <span className="inline-block rounded-md border border-border/60 bg-muted/30 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/90">
                         {category}
                       </span>
                       <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                        <time className="lowercase" dateTime={new Date(date).toISOString()}>
+                        <time dateTime={new Date(date).toISOString()}>
                           {new Intl.DateTimeFormat(undefined, { year: 'numeric', month: 'short', day: 'numeric' }).format(new Date(date))}
                         </time>
                         <span className="text-border/70" aria-hidden>
@@ -126,10 +126,10 @@ export default function BlogPostLayout({
                         <span className="font-medium text-foreground/80 normal-case">By {author}</span>
                       </div>
                     </div>
-                    <h1 className="type-h1 font-semibold text-balance">
+                    <h1 className="blog-post-title text-balance">
                       {h1Title || title}
                     </h1>
-                    <p className="mt-4 max-w-[68ch] type-lead">
+                    <p className="blog-post-lead mt-4 max-w-[70ch]">
                       {description}
                     </p>
                     <div className="mt-5 flex flex-wrap items-center justify-start gap-3">
@@ -166,10 +166,10 @@ export default function BlogPostLayout({
                 {relatedPosts.length > 0 && (
                   <section className="mt-16 rounded-2xl border border-border/60 bg-card/40 p-6 sm:p-8">
                     <div className="flex flex-col gap-2 mb-6">
-                      <p className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground font-pixel">keep learning</p>
-                      <h2 className="text-2xl font-bold tracking-tight lowercase">related posts</h2>
-                      <p className="text-sm text-muted-foreground lowercase">
-                        more experiments and playbooks from the prism team.
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Keep learning</p>
+                      <h2 className="text-2xl font-bold tracking-tight">Related posts</h2>
+                      <p className="text-sm text-muted-foreground">
+                        More experiments and playbooks from the Prism team.
                       </p>
                     </div>
                     <div className="grid grid-cols-1 gap-6 md:grid-cols-3">

--- a/components/blog/BlogTableOfContents.tsx
+++ b/components/blog/BlogTableOfContents.tsx
@@ -64,7 +64,7 @@ export default function BlogTableOfContents({ items, className }: BlogTableOfCon
       <div className="lg:hidden">
         <div className="rounded-2xl border border-border/60 bg-card/40 p-4 shadow-sm shadow-black/40 backdrop-blur supports-[backdrop-filter]:bg-card/30">
           <div className="flex items-center justify-between">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.32em] text-muted-foreground font-pixel">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
               on this page
             </p>
             <span className="text-xs text-muted-foreground/80">{items.length} sections</span>
@@ -96,8 +96,8 @@ export default function BlogTableOfContents({ items, className }: BlogTableOfCon
       <nav className="hidden lg:block" aria-label="Table of contents">
         <div className="sticky top-28 rounded-3xl border border-border/60 bg-card/40 p-5 shadow-sm shadow-black/40 backdrop-blur supports-[backdrop-filter]:bg-card/30">
           <div>
-            <p className="text-[10px] font-semibold uppercase tracking-[0.32em] text-muted-foreground font-pixel">on this page</p>
-            <p className="mt-1 text-sm text-muted-foreground">jump to the section you need.</p>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">on this page</p>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">jump to the section you need.</p>
           </div>
           <ul className="mt-4 space-y-1.5">
             {items.map((item) => {

--- a/components/simple-blog-post-card.tsx
+++ b/components/simple-blog-post-card.tsx
@@ -41,7 +41,7 @@ export default function SimpleBlogPostCard({
         <div className={cn("relative w-full aspect-[4/3] overflow-hidden", gradientClass)} />
         <div className="flex flex-1 flex-col space-y-3 border-t border-border/60 p-5">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <span className="inline-flex items-center rounded-md border border-border/60 bg-muted/40 px-2.5 py-1 text-[10px] font-semibold uppercase font-pixel tracking-[0.16em] text-muted-foreground">
+            <span className="inline-flex items-center rounded-md border border-border/60 bg-muted/40 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
               {category}
             </span>
             <div className="flex flex-wrap items-center justify-end gap-x-1 gap-y-1 text-xs text-muted-foreground">
@@ -54,16 +54,16 @@ export default function SimpleBlogPostCard({
               <span className="font-medium text-foreground/80 normal-case">By {author}</span>
             </div>
           </div>
-          <h3 className="text-lg font-semibold leading-snug text-balance text-foreground">
+          <h3 className="blog-card-title text-balance text-foreground">
             {title}
           </h3>
           {!compact && (
-            <p className="text-sm/6 text-muted-foreground line-clamp-3">
+            <p className="blog-card-description text-muted-foreground line-clamp-3">
               {description}
             </p>
           )}
-          <div className="flex items-center pt-1 text-xs font-semibold uppercase tracking-[0.18em] text-foreground font-pixel">
-            read post
+          <div className="flex items-center pt-1 text-xs font-semibold uppercase tracking-[0.12em] text-foreground">
+            Read post
             <ArrowRight className="ml-1 h-4 w-4" aria-hidden="true" focusable="false" />
           </div>
         </div>

--- a/docs/blog-styling-guide.md
+++ b/docs/blog-styling-guide.md
@@ -7,7 +7,8 @@ The blog styling system has been improved to provide clean, consistent, and read
 ## Key Improvements
 
 1. **Better Readability**
-   - Optimized font size (17px base) for comfortable reading
+   - Blog index + post pages now use the Inter typeface (`next/font/google`)
+   - Optimized body font size (`clamp(1.06rem, 0.98rem + 0.24vw, 1.2rem)`) for comfortable reading
    - Improved line height and spacing between elements
    - Softer text colors to reduce eye strain
    - Consistent spacing throughout the article
@@ -22,7 +23,7 @@ The blog styling system has been improved to provide clean, consistent, and read
 3. **Clean Content**
    - Avoid inline Tailwind classes/styles in MDX (they can cause visual drift)
    - Preserves special components like CTAs and embeds
-   - Maintains the lowercase aesthetic while improving readability
+   - Prioritizes sentence case and cleaner letter spacing for long-form readability
 
 ## Writing Blog Posts
 
@@ -97,8 +98,8 @@ This is an informational callout box.
 
 The blog styling system consists of:
 
-1. **prose-blog** class: Custom Tailwind prose configuration
-2. **lowercase-prose** class: Maintains the brand's lowercase aesthetic
+1. **`app/blog/layout.tsx`**: Applies Inter only within the blog route segment
+2. **`blog-reading-surface` + `prose-blog` classes**: Route-scoped typography tuning for long-form reading
 3. **MDX renderer**: Cleans up inline styles automatically
 4. **Dark mode**: Automatic color adjustments for dark theme
 


### PR DESCRIPTION
## Summary
- apply Inter to the entire `/blog` route segment via a dedicated `app/blog/layout.tsx`
- retune blog typography for long-form reading in `app/globals.css` (`blog-reading-surface`, `blog-display-title`, `blog-post-title`, `prose-blog` sizing/line-height/spacing)
- reduce stylized/pixel label usage on blog index/post UI (filters, cards, TOC, post meta, email signup) and improve sentence-case readability cues
- update blog docs to reflect the route-scoped Inter setup and revised readability system

## What changed
- **Route font scope:** Added `app/blog/layout.tsx` with `next/font/google` Inter so blog index + blog post pages use Inter without changing the rest of the site.
- **Reading UX pass:** Adjusted prose scale, line-height, heading rhythm, and list spacing for easier scanning and sustained reading.
- **Surface typography cleanup:** Updated key blog UI strings and labels to less stylized presentation and improved supporting text sizing.
- **Docs:** Updated `docs/blog-styling-guide.md` to document the new typography architecture.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- Visual review in local dev (`/blog`, `/blog/[slug]`)

## Screenshots
- Blog index typography: ![Blog index typography](browser:/tmp/codex_browser_invocations/b42f5bc9a720a024/artifacts/artifacts/blog-index-typography.png)
- Blog post typography: ![Blog post typography](browser:/tmp/codex_browser_invocations/b42f5bc9a720a024/artifacts/artifacts/blog-post-typography.png)

## Notes
- In local dev, Next emitted transient TLS warnings while fetching Inter from Google Fonts and fell back to system fonts during that run. The route-level Inter integration is in place in code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bf807c6f88321b38d703eb9007fe6)