### PR TITLE
Remove forced lowercase styling across blog experience

### DIFF
--- a/app/blog/BlogCTAButton.tsx
+++ b/app/blog/BlogCTAButton.tsx
@@ -43,7 +43,7 @@ export default function BlogCTAButton() {
     <Link href="/free-analysis">
       <motion.button
         ref={ref}
-        className="relative inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-medium text-white lowercase overflow-hidden group"
+        className="relative inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-medium text-white overflow-hidden group"
         onClick={() => trackCTAClick(FREE_AUDIT_CTA_TEXT, "blog page")}
         onMouseMove={handleMouseMove}
         onMouseEnter={() => setIsHovered(true)}

--- a/app/blog/BlogCTAButtonLazy.tsx
+++ b/app/blog/BlogCTAButtonLazy.tsx
@@ -11,7 +11,7 @@ const BlogCTAButton = dynamic(() => import("./BlogCTAButton"), {
   loading: () => (
     <Link
       href="/free-analysis"
-      className="inline-flex items-center justify-center gap-2 rounded-full bg-neutral-900 px-6 py-3 text-sm font-medium lowercase text-white transition hover:bg-neutral-800"
+      className="inline-flex items-center justify-center gap-2 rounded-full bg-neutral-900 px-6 py-3 text-sm font-medium text-white transition hover:bg-neutral-800"
       data-cta-text={FREE_AUDIT_CTA_TEXT}
       data-cta-location="blog page"
     >

--- a/app/blog/BlogPage.tsx
+++ b/app/blog/BlogPage.tsx
@@ -40,13 +40,13 @@ export default function BlogPage({ posts }: { posts: BlogPost[] }) {
       <Navbar />
       <main className="flex-1 relative">
         <div className="container mx-auto px-4 md:px-6">
-          <Breadcrumbs items={[{ name: "home", url: "/" }, { name: "blog", url: "/blog" }]} />
+          <Breadcrumbs items={[{ name: "Home", url: "/" }, { name: "Blog", url: "/blog" }]} />
         </div>
         {/* Minimal hero */}
         <section className="py-6 md:py-10 border-b border-neutral-100">
           <div className="container mx-auto px-4 md:px-6">
-            <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold tracking-tight lowercase">insights & ideas</h1>
-            <p className="text-neutral-600 mt-2 lowercase">thoughts on design, development, and digital strategy from the prism team</p>
+            <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold tracking-tight">Insights & ideas</h1>
+            <p className="text-neutral-600 mt-2">Thoughts on design, development, and digital strategy from the Prism team</p>
           </div>
         </section>
 
@@ -61,8 +61,8 @@ export default function BlogPage({ posts }: { posts: BlogPost[] }) {
         <section className="py-12 md:py-16 bg-neutral-50">
           <div className="container mx-auto px-4 md:px-6">
             <div className="mx-auto max-w-2xl space-y-4 text-center">
-              <h2 className="text-2xl font-bold tracking-tighter lowercase sm:text-3xl">want to work with us?</h2>
-              <p className="text-neutral-600 lowercase">let's discuss how we can help your business grow</p>
+              <h2 className="text-2xl font-bold tracking-tighter sm:text-3xl">Want to work with us?</h2>
+              <p className="text-neutral-600">Let's discuss how we can help your business grow</p>
               <div className="pt-4">
                 <BlogCTAButton />
               </div>
@@ -71,10 +71,10 @@ export default function BlogPage({ posts }: { posts: BlogPost[] }) {
         </section>
 
         {/* SEO supporting copy */}
-        <SeoTextSection title="prism blog: design, development, and growth">
+        <SeoTextSection title="Prism blog: design, development, and growth">
           <p>
-            we publish practical notes on product design, engineering, and modern seo—how to ship faster,
-            write clearer interfaces, and measure what matters. each post is written from real client work
+            We publish practical notes on product design, engineering, and modern SEO—how to ship faster,
+            write clearer interfaces, and measure what matters. Each post is written from real client work
             and experiments, not theory.
           </p>
         </SeoTextSection>

--- a/app/blog/BlogPostsList.tsx
+++ b/app/blog/BlogPostsList.tsx
@@ -59,9 +59,9 @@ export default function BlogPostsList({ posts }: { posts: BlogPost[] }) {
             </SimpleBlogGrid>
           ) : (
             <div className="rounded-md border border-dashed border-border/60 bg-card/20 py-16 text-center">
-              <h3 className="mb-2 text-xl font-semibold text-foreground">no posts found</h3>
+              <h3 className="mb-2 text-xl font-semibold text-foreground">No posts found</h3>
               <p className="text-muted-foreground">
-                try adjusting your filters or search query
+                Try adjusting your filters or search query
               </p>
             </div>
           )}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -70,7 +70,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   // Compute concise SEO title (avoid layout template and long strings)
   const maxTitleLength = 60
-  const rawTitle = (frontmatter.title || "blog post").toLowerCase()
+  const rawTitle = frontmatter.title || "Blog post"
   const brandSuffix = " | prism"
   const seoTitle =
     rawTitle.length + brandSuffix.length <= maxTitleLength

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -151,10 +151,10 @@ export default async function Blog({
           </div>
         </section>
 
-        <SeoTextSection title="prism blog: design, development, and growth">
+        <SeoTextSection title="Prism blog: design, development, and growth">
           <p>
-            we publish practical notes on product design, engineering, and modern seo—how to ship faster,
-            write clearer interfaces, and measure what matters. each post is written from real client work
+            We publish practical notes on product design, engineering, and modern SEO—how to ship faster,
+            write clearer interfaces, and measure what matters. Each post is written from real client work
             and experiments, not theory.
           </p>
         </SeoTextSection>

--- a/components/blog-error-boundary.tsx
+++ b/components/blog-error-boundary.tsx
@@ -82,30 +82,30 @@ function BlogErrorFallback({ error, retry }: { error: Error; retry: () => void }
       <div className="text-center max-w-md mx-auto">
         <div className="mb-6">
           <AlertTriangle className="h-16 w-16 text-red-500 mx-auto mb-4" />
-          <h2 className="text-2xl font-bold text-neutral-900 lowercase mb-2">
-            {isMDXError ? 'blog post failed to load' : 'something went wrong'}
+          <h2 className="text-2xl font-bold text-neutral-900 mb-2">
+            {isMDXError ? 'Blog post failed to load' : 'Something went wrong'}
           </h2>
-          <p className="text-neutral-600 lowercase">
+          <p className="text-neutral-600">
             {isMDXError 
-              ? 'there was an error loading this blog post. please try again or go back to the blog list.'
-              : 'we encountered an unexpected error. please try refreshing the page.'
+              ? 'There was an error loading this blog post. Please try again or go back to the blog list.'
+              : 'We encountered an unexpected error. Please try refreshing the page.'
             }
           </p>
         </div>
         
         <div className="space-y-3">
-          <Button onClick={retry} className="lowercase bg-neutral-900 text-white hover:bg-neutral-800">
+          <Button onClick={retry} className="bg-neutral-900 text-white hover:bg-neutral-800">
             <RefreshCw />
-            try again
+            Try again
           </Button>
           
           <div>
             <Link
               href="/blog"
-              className="inline-flex items-center px-4 py-2 text-neutral-600 hover:text-neutral-900 transition-colors lowercase"
+              className="inline-flex items-center px-4 py-2 text-neutral-600 hover:text-neutral-900 transition-colors"
             >
               <ArrowLeft className="h-4 w-4 mr-2" />
-              back to blog
+              Back to blog
             </Link>
           </div>
         </div>
@@ -135,16 +135,16 @@ export function BlogPostErrorBoundary({ children }: { children: React.ReactNode 
             <div className="flex items-start">
               <AlertTriangle className="h-5 w-5 text-red-600 mt-0.5 mr-3 shrink-0" />
               <div>
-                <h3 className="text-lg font-semibold text-red-900 lowercase mb-2">
-                  failed to render blog content
+                <h3 className="text-lg font-semibold text-red-900 mb-2">
+                  Failed to render blog content
                 </h3>
-                <p className="text-red-700 lowercase mb-4">
-                  there was an error processing the blog post content. this might be due to invalid 
+                <p className="text-red-700 mb-4">
+                  There was an error processing the blog post content. This might be due to invalid 
                   formatting or a temporary issue.
                 </p>
-                <Button onClick={retry} variant="destructive" size="sm" className="lowercase">
+                <Button onClick={retry} variant="destructive" size="sm">
                   <RefreshCw />
-                  retry loading
+                  Retry loading
                 </Button>
               </div>
             </div>
@@ -174,15 +174,15 @@ export function BlogListErrorBoundary({ children }: { children: React.ReactNode 
           <div className="container mx-auto px-4 md:px-6">
             <div className="text-center py-16 border border-dashed border-red-200 rounded-lg bg-red-50">
               <AlertTriangle className="h-12 w-12 text-red-500 mx-auto mb-4" />
-              <h3 className="text-xl font-medium text-red-900 lowercase mb-2">
-                failed to load blog posts
+              <h3 className="text-xl font-medium text-red-900 mb-2">
+                Failed to load blog posts
               </h3>
-              <p className="text-red-700 lowercase mb-6">
-                we couldn't load the blog posts right now. please try again.
+              <p className="text-red-700 mb-6">
+                We couldn't load the blog posts right now. Please try again.
               </p>
-              <Button onClick={retry} variant="destructive" className="lowercase">
+              <Button onClick={retry} variant="destructive">
                 <RefreshCw />
-                retry loading
+                Retry loading
               </Button>
             </div>
           </div>

--- a/components/blog-filter-navigation.tsx
+++ b/components/blog-filter-navigation.tsx
@@ -54,7 +54,7 @@ export default function BlogFilterNavigation({
   }, [posts, searchQuery, selectedCategory, onFilteredPostsChange])
 
   const buttonCategories = [
-    { slug: "all", label: "all" },
+    { slug: "all", label: "All" },
     ...categories.map((c) => ({ slug: c.slug, label: c.label })),
   ]
 
@@ -107,9 +107,9 @@ export default function BlogFilterNavigation({
               <ToggleGroupItem
                 key={category.slug}
                 value={category.slug}
-                className="rounded-md border border-border/60 bg-muted/20 px-4 py-2 text-xs font-semibold lowercase text-muted-foreground transition-colors duration-200 hover:bg-muted/40 hover:text-foreground data-[state=on]:border-white/30 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+                className="rounded-md border border-border/60 bg-muted/20 px-4 py-2 text-xs font-semibold text-muted-foreground transition-colors duration-200 hover:bg-muted/40 hover:text-foreground data-[state=on]:border-white/30 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
               >
-                {category.label.toLowerCase()}
+                {category.label}
               </ToggleGroupItem>
             ))}
           </ToggleGroup>

--- a/components/blog-post-card.tsx
+++ b/components/blog-post-card.tsx
@@ -69,7 +69,7 @@ export default function BlogPostCard({
   }
 
   return (
-    <Link href={`/blog/${slug}`} onClick={() => trackCTAClick(`view blog post`, title)} className="block">
+    <Link href={`/blog/${slug}`} onClick={() => trackCTAClick(`View blog post`, title)} className="block">
       <motion.div
         ref={ref}
         className="relative h-full cursor-pointer group"
@@ -92,14 +92,14 @@ export default function BlogPostCard({
           {featured && (
             <Badge
               asChild
-              className="absolute left-3 top-3 z-10 rounded-full bg-black/80 px-3 py-1 text-xs lowercase text-white"
+              className="absolute left-3 top-3 z-10 rounded-full bg-black/80 px-3 py-1 text-xs text-white"
             >
               <motion.div
                 initial={{ scale: 0, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 transition={{ delay: 0.3, duration: 0.3 }}
               >
-                featured
+                Featured
               </motion.div>
             </Badge>
           )}
@@ -131,34 +131,34 @@ export default function BlogPostCard({
               >
                 <Badge
                   variant="secondary"
-                  className="rounded-full bg-neutral-100 px-3 py-1 text-xs lowercase text-neutral-700"
+                  className="rounded-full bg-neutral-100 px-3 py-1 text-xs text-neutral-700"
                 >
                   {category}
                 </Badge>
               </motion.div>
-              <div className="text-sm text-neutral-500 lowercase">{date}</div>
+              <div className="text-sm text-neutral-500">{date}</div>
             </div>
             <motion.h3 
-              className="text-lg font-bold lowercase"
+              className="text-lg font-bold"
               style={{ transform: "translateZ(30px)" }}
             >
               {title}
             </motion.h3>
             {!compact && (
               <motion.p 
-                className="text-neutral-600 lowercase"
+                className="text-neutral-600"
                 style={{ transform: "translateZ(20px)" }}
               >
                 {description}
               </motion.p>
             )}
             <motion.div 
-              className="flex items-center pt-2 text-sm font-medium text-neutral-900 lowercase"
+              className="flex items-center pt-2 text-sm font-medium text-neutral-900"
               style={{ transform: "translateZ(40px)" }}
               whileHover={{ x: 4 }}
               transition={{ duration: 0.2 }}
             >
-              read post 
+              Read post 
               <motion.div
                 animate={{ x: [0, 4, 0] }}
                 transition={{ duration: 1.5, repeat: Infinity, ease: "easeInOut" }}

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -127,8 +127,8 @@ export const MDXComponents = {
     href?: string;
   }) => (
     <div className="my-12 p-8 bg-neutral-50 dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800">
-      <h3 className="text-xl font-bold mb-2 lowercase">{title}</h3>
-      <p className="text-neutral-600 dark:text-neutral-400 mb-6 lowercase">{description}</p>
+      <h3 className="text-xl font-bold mb-2">{title}</h3>
+      <p className="text-neutral-600 dark:text-neutral-400 mb-6">{description}</p>
       <CTAButton href={href}>
         {href?.startsWith("/get-started") ? FREE_AUDIT_CTA_TEXT : buttonText ?? FREE_AUDIT_CTA_TEXT}
       </CTAButton>
@@ -183,7 +183,7 @@ export const MDXComponents = {
     children: ReactNode;
   }) => (
     <div className="border border-neutral-200 dark:border-neutral-800 p-4 rounded-lg">
-      {title && <h4 className="font-semibold mb-2 lowercase">{title}</h4>}
+      {title && <h4 className="font-semibold mb-2">{title}</h4>}
       <div className="text-neutral-600 dark:text-neutral-400">{children}</div>
     </div>
   ),

--- a/components/mobile-blog-grid.tsx
+++ b/components/mobile-blog-grid.tsx
@@ -333,7 +333,7 @@ export function PerformantMobileBlogGrid({ children, posts, className = "" }: Mo
             onClick={handleLoadMore}
             className="
               px-6 py-3 bg-neutral-900 text-white rounded-full
-              font-medium text-sm lowercase
+              font-medium text-sm
               hover:bg-neutral-800 transition-colors
               focus:outline-hidden focus:ring-2 focus:ring-neutral-500
               active:scale-95 transition-transform

--- a/components/mobile-blog-post-card.tsx
+++ b/components/mobile-blog-post-card.tsx
@@ -67,12 +67,12 @@ export default function MobileBlogPostCard({
         {/* Featured badge */}
         {featured && (
           <motion.div 
-            className="absolute top-3 left-3 text-xs text-white bg-black/80 px-3 py-1 rounded-full lowercase z-10"
+            className="absolute top-3 left-3 text-xs text-white bg-black/80 px-3 py-1 rounded-full z-10"
             initial={{ scale: 0, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             transition={{ delay: 0.2, duration: 0.3 }}
           >
-            featured
+            Featured
           </motion.div>
         )}
         
@@ -99,7 +99,7 @@ export default function MobileBlogPostCard({
           {/* Category and metadata */}
           <div className="flex items-center justify-between gap-2">
             <motion.div 
-              className="inline-flex items-center px-3 py-1 bg-neutral-100 rounded-full text-xs font-medium lowercase"
+              className="inline-flex items-center px-3 py-1 bg-neutral-100 rounded-full text-xs font-medium"
               whileHover={!isMobile && !reducedMotion ? { scale: 1.05 } : {}}
               transition={{ duration: 0.2 }}
             >
@@ -120,7 +120,7 @@ export default function MobileBlogPostCard({
           
           {/* Title */}
           <h3 className={`
-            font-bold lowercase leading-tight
+            font-bold leading-tight
             ${isMobile ? 'text-lg' : 'text-xl'}
             ${compact ? 'line-clamp-2' : 'line-clamp-3'}
           `}>
@@ -130,7 +130,7 @@ export default function MobileBlogPostCard({
           {/* Description */}
           {!compact && (
             <p className={`
-              text-neutral-600 lowercase leading-relaxed
+              text-neutral-600 leading-relaxed
               ${isMobile ? 'text-sm line-clamp-2' : 'text-base line-clamp-3'}
             `}>
               {description}
@@ -140,11 +140,11 @@ export default function MobileBlogPostCard({
           {/* Read more link */}
           <div className="flex items-center justify-between pt-2">
             <motion.div 
-              className="flex items-center text-sm font-medium text-neutral-900 lowercase"
+              className="flex items-center text-sm font-medium text-neutral-900"
               whileHover={!isMobile && !reducedMotion ? { x: 4 } : {}}
               transition={{ duration: 0.2 }}
             >
-              <span>read post</span>
+              <span>Read post</span>
               <motion.div
                 className="ml-1"
                 animate={!reducedMotion ? { x: [0, 4, 0] } : {}}
@@ -236,17 +236,17 @@ export function CompactMobileBlogPostCard({
           <div className="flex-1 p-4 flex flex-col justify-between min-h-0">
             <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <span className="text-xs px-2 py-1 bg-neutral-100 rounded-full lowercase">
+                <span className="text-xs px-2 py-1 bg-neutral-100 rounded-full">
                   {category}
                 </span>
                 {featured && (
-                  <span className="text-xs px-2 py-1 bg-black text-white rounded-full lowercase">
-                    featured
+                  <span className="text-xs px-2 py-1 bg-black text-white rounded-full">
+                    Featured
                   </span>
                 )}
               </div>
               
-              <h3 className="text-sm font-bold lowercase leading-tight line-clamp-2">
+              <h3 className="text-sm font-bold leading-tight line-clamp-2">
                 {title}
               </h3>
               
@@ -258,7 +258,7 @@ export function CompactMobileBlogPostCard({
             </div>
             
             <div className="flex items-center justify-between mt-2">
-              <span className="text-xs text-neutral-600 lowercase">read post</span>
+              <span className="text-xs text-neutral-600">Read post</span>
               <ArrowRight className="h-3 w-3 text-neutral-400" />
             </div>
           </div>

--- a/components/optimized-blog-post-card.tsx
+++ b/components/optimized-blog-post-card.tsx
@@ -78,8 +78,8 @@ export default function OptimizedBlogPostCard({
           )}
         >
           {featured && (
-            <div className="absolute top-3 left-3 text-xs text-white bg-black/80 px-3 py-1 rounded-full lowercase z-10 hardware-accelerated">
-              featured
+            <div className="absolute top-3 left-3 text-xs text-white bg-black/80 px-3 py-1 rounded-full z-10 hardware-accelerated">
+              Featured
             </div>
           )}
           
@@ -110,7 +110,7 @@ export default function OptimizedBlogPostCard({
           <div className="p-5 space-y-3 border-t border-neutral-100 flex-1 flex flex-col">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
               <motion.div 
-                className="inline-block px-3 py-1 bg-neutral-100 rounded-full text-xs lowercase w-fit"
+                className="inline-block px-3 py-1 bg-neutral-100 rounded-full text-xs w-fit"
                 animate={{
                   scale: isHovered ? 1.05 : 1
                 }}
@@ -118,27 +118,27 @@ export default function OptimizedBlogPostCard({
               >
                 {category}
               </motion.div>
-              <div className="text-sm text-neutral-500 lowercase">{date}</div>
+              <div className="text-sm text-neutral-500">{date}</div>
             </div>
             
-            <h3 className="text-lg font-bold lowercase">
+            <h3 className="text-lg font-bold">
               {title}
             </h3>
             
             {!compact && (
-              <p className="text-neutral-600 lowercase flex-1">
+              <p className="text-neutral-600 flex-1">
                 {description}
               </p>
             )}
             
             <motion.div 
-              className="flex items-center text-sm font-medium text-neutral-900 lowercase pt-2"
+              className="flex items-center text-sm font-medium text-neutral-900 pt-2"
               animate={{
                 x: isHovered ? 4 : 0
               }}
               transition={{ duration: 0.2 }}
             >
-              read post 
+              Read post 
               <ArrowRight className="ml-1 h-4 w-4" />
             </motion.div>
           </div>

--- a/content/blog/business-visibility-chatgpt.mdx
+++ b/content/blog/business-visibility-chatgpt.mdx
@@ -84,9 +84,9 @@ If you have any questions or want to learn more about how we can help your busin
 </div>
 
 <div className="mt-12 p-6 bg-neutral-50 dark:bg-neutral-800/50 rounded-lg border border-neutral-200 dark:border-neutral-700/50">
-  <h3 className="text-xl font-bold mb-2 lowercase">want to improve your ai search ranking?</h3>
-  <p className="text-neutral-600 dark:text-neutral-400 mb-6 lowercase">let prism help your business get noticed by ai.</p>
+  <h3 className="text-xl font-bold mb-2">Want to improve your AI search ranking?</h3>
+  <p className="text-neutral-600 dark:text-neutral-400 mb-6">Let Prism help your business get noticed by AI.</p>
   <CTAButton href="/get-started" block>
-    get started
+    Get started
   </CTAButton>
 </div>

--- a/content/blog/modern-reviews-strategy-2025.mdx
+++ b/content/blog/modern-reviews-strategy-2025.mdx
@@ -25,7 +25,7 @@ twitter:
 canonical: "https://www.design-prism.com/blog/modern-reviews-strategy-2025"
 ---
 
-<div className="lowercase">
+<div>
 
 ## Why Reviews Still Matter
 

--- a/content/blog/reusable-shadcn-codex-template.mdx
+++ b/content/blog/reusable-shadcn-codex-template.mdx
@@ -31,7 +31,7 @@ canonical: "https://www.design-prism.com/blog/reusable-shadcn-codex-template"
 
 <section className="rounded-3xl border border-neutral-200 bg-neutral-50 p-8 shadow-sm flex flex-col gap-4">
   <div>
-    <h2 className="text-2xl font-semibold leading-tight tracking-tight text-neutral-900 lowercase">turn your ui into a system - not a rebuild</h2>
+    <h2 className="text-2xl font-semibold leading-tight tracking-tight text-neutral-900">Turn your UI into a system — not a rebuild</h2>
     <p className="mt-3 text-sm text-neutral-600">
       in less than 15 minutes you can spin up a reusable shadcn/ui design system that codex automatically understands. build once, reuse everywhere, and stop recreating buttons, inputs, and tables for every engagement.
     </p>

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -54,8 +54,8 @@ Custom confirmation routes live in `app/thank-you/` and `app/analysis-thank-you/
 Any CTA labeled “free analysis” should point to `/free-analysis`. When you add a new CTA, double-check the href so we don’t regress to `/get-started` accidentally.
 
 ## Typography & Casing
-- The global stylesheet forces the brand’s lowercase aesthetic via `body { text-transform: lowercase !important; }`.
-- All UI text should stay lowercase end-to-end; do not introduce casing overrides or `text-transform: none` escape hatches.
+- Do not enforce global lowercase transforms for site copy; preserve natural capitalization for readability.
+- Use Tailwind text-transform utilities only when a specific component intentionally needs stylistic casing.
 
 ## UI Components (shadcn/ui)
 The site uses shadcn/ui primitives under `components/ui/` (Tailwind + Radix + `cn()` helpers) with the `radix-vega` preset (neutral palette + subtle menu accent, Inter as `--font-sans`). Add new primitives via the CLI so we stay aligned with upstream.


### PR DESCRIPTION
## Summary
- removed the old forced-lowercase presentation from blog routes, blog cards, blog filters, error boundaries, and MDX blog helper components
- updated blog-facing copy to normal capitalization for readability (headings, CTAs, empty states, and link labels)
- stopped lowercasing blog post SEO titles in `app/blog/[slug]/page.tsx`
- cleaned up blog MDX posts that explicitly wrapped content/CTAs with lowercase styling
- updated `docs/development-guide.md` typography guidance to reflect the new capitalization policy

## Files touched
- `app/blog/BlogCTAButton.tsx`
- `app/blog/BlogCTAButtonLazy.tsx`
- `app/blog/BlogPage.tsx`
- `app/blog/BlogPostsList.tsx`
- `app/blog/[slug]/page.tsx`
- `app/blog/page.tsx`
- `components/blog-error-boundary.tsx`
- `components/blog-filter-navigation.tsx`
- `components/blog-post-card.tsx`
- `components/mdx-components.tsx`
- `components/mobile-blog-grid.tsx`
- `components/mobile-blog-post-card.tsx`
- `components/optimized-blog-post-card.tsx`
- `content/blog/business-visibility-chatgpt.mdx`
- `content/blog/modern-reviews-strategy-2025.mdx`
- `content/blog/reusable-shadcn-codex-template.mdx`
- `docs/development-guide.md`

## Validation
- static inspection only (no runtime tests executed in this pass)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bfc5029b083218ddf274fbab6cba3)