### PR TITLE
Update blog featured and Open Graph images

### DIFF
--- a/content/blog/ai-rip-eyes-out-dental-software.mdx
+++ b/content/blog/ai-rip-eyes-out-dental-software.mdx
@@ -4,7 +4,11 @@ author: "Enzo Sison"
 description: "AI is collapsing bloated dental PMS vendors and enabling practice-owned operating systems: faster iteration, fewer dashboards, better patient experience."
 date: "2026-02-09"
 category: "AI & Dentistry"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770782010/Surfer_izwncy.png"
 gradientClass: "bg-gradient-to-br from-rose-300/30 via-amber-300/30 to-emerald-300/30"
+openGraph:
+  images:
+    - url: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770782010/Surfer_izwncy.png"
 ---
 
 *By Enzo Sison, Founder of Prism*

--- a/content/blog/openclaw-manus-codex-scaling-business.mdx
+++ b/content/blog/openclaw-manus-codex-scaling-business.mdx
@@ -4,7 +4,7 @@ author: "Gwen Smith"
 description: "how openclaw, manus, and codex helped us fix a client seo fire, migrate infrastructure safely, and scale prism with a digital employee."
 date: "2026-02-03"
 category: "web ops & tooling"
-image: "/blog/custom-website-development.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770782009/Skier_xzs8az.png"
 gradientClass: "bg-gradient-to-br from-sky-300/30 via-emerald-200/30 to-amber-200/30"
 showHeroImage: false
 openGraph:
@@ -13,7 +13,7 @@ openGraph:
   url: "https://www.design-prism.com/blog/openclaw-manus-codex-scaling-business"
   siteName: "prism"
   images:
-    - url: "/blog/custom-website-development.png"
+    - url: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770782009/Skier_xzs8az.png"
       width: 1200
       height: 630
       alt: "Modern website infrastructure tooling"
@@ -25,7 +25,7 @@ twitter:
   card: "summary_large_image"
   title: "openclaw, manus, and codex are scaling my business"
   description: "the agent stack that turned a messy seo problem into a clean, no-downtime migration."
-  images: ["/blog/custom-website-development.png"]
+  images: ["https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770782009/Skier_xzs8az.png"]
 canonical: "https://www.design-prism.com/blog/openclaw-manus-codex-scaling-business"
 ---
 


### PR DESCRIPTION
## Summary
- set the featured image and Open Graph image for `AI Is About to Rip the Eyes Out of Dental Software And That's Great News for Dentists` to `https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770782010/Surfer_izwncy.png`
- set the featured image and Open Graph image for `openclaw, manus, and codex are scaling my business` to `https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770782009/Skier_xzs8az.png`
- aligned the second post's Twitter image with the updated featured/Open Graph asset for consistency

## Files changed
- `content/blog/ai-rip-eyes-out-dental-software.mdx`
- `content/blog/openclaw-manus-codex-scaling-business.mdx`

## Validation
- verified frontmatter now contains updated `image` and `openGraph.images` URLs for both posts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bfe1d57288321a77cd4ac672fc130)