### PR TITLE
Show blog featured images in preview cards

### DIFF
--- a/app/ads/page.tsx
+++ b/app/ads/page.tsx
@@ -492,7 +492,7 @@ export default async function AdsPage() {
                     author={post.author}
                     description={post.description}
                     slug={post.slug}
-                    image={post.image || "/blog/ai-digital-marketing.png"}
+                    image={post.image}
                     gradientClass={post.gradientClass}
                   />
                 ))}

--- a/app/blog/BlogPostsList.tsx
+++ b/app/blog/BlogPostsList.tsx
@@ -51,7 +51,7 @@ export default function BlogPostsList({ posts }: { posts: BlogPost[] }) {
                   author={post.author}
                   description={post.description}
                   slug={post.slug}
-                  image={post.image || '/blog/ai-digital-marketing.png'}
+                  image={post.image}
                   featured={post.featured}
                   gradientClass={post.gradientClass}
                 />

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -122,7 +122,7 @@ export default async function Blog({
                       author={post.author}
                       description={post.description}
                       slug={post.slug}
-                      image={post.image || "/blog/ai-digital-marketing.png"}
+                      image={post.image}
                       gradientClass={post.gradientClass}
                       prefetch={false}
                   />

--- a/app/local-listings/page.tsx
+++ b/app/local-listings/page.tsx
@@ -494,7 +494,7 @@ export default async function LocalListingsPage() {
                     author={post.author}
                     description={post.description}
                     slug={post.slug}
-                    image={post.image || "/blog/ai-digital-marketing.png"}
+                    image={post.image}
                     gradientClass={post.gradientClass}
                   />
                 ))}

--- a/app/seo/page.tsx
+++ b/app/seo/page.tsx
@@ -519,7 +519,7 @@ export default async function SeoPage() {
                   author={post.author}
                   description={post.description}
                   slug={post.slug}
-                  image={post.image || "/blog/ai-digital-marketing.png"}
+                  image={post.image}
                   gradientClass={post.gradientClass}
                 />
               ))}

--- a/app/websites/page.tsx
+++ b/app/websites/page.tsx
@@ -569,7 +569,7 @@ export default async function WebsitesPage() {
                     author={post.author}
                     description={post.description}
                     slug={post.slug}
-                    image={post.image || "/blog/ai-digital-marketing.png"}
+                    image={post.image}
                     gradientClass={post.gradientClass}
                   />
                 ))}

--- a/components/blog-post-layout.tsx
+++ b/components/blog-post-layout.tsx
@@ -182,7 +182,7 @@ export default function BlogPostLayout({
                             author={related.author}
                             description={related.description}
                             slug={related.slug}
-                            image={related.image ?? "/blog/ai-digital-marketing.png"}
+                            image={related.image}
                             gradientClass={related.gradientClass}
                             compact
                         />

--- a/components/home/LatestPostsSection.tsx
+++ b/components/home/LatestPostsSection.tsx
@@ -17,7 +17,6 @@ type LatestPost = {
   gradientClass?: string | null
 }
 
-const FALLBACK_IMAGE = "/blog/ai-digital-marketing.png"
 const FALLBACK_GRADIENT = "bg-gradient-to-br from-neutral-200 via-neutral-100 to-white"
 const MAX_RETRIES = 3
 const RETRY_DELAY_MS = 1500
@@ -154,7 +153,7 @@ export default function LatestPostsSection() {
                 author={post.author}
                 description={post.description}
                 slug={post.slug}
-                image={post.image ?? FALLBACK_IMAGE}
+                image={post.image}
                 gradientClass={post.gradientClass ?? FALLBACK_GRADIENT}
                 compact
               />

--- a/components/simple-blog-post-card.tsx
+++ b/components/simple-blog-post-card.tsx
@@ -9,7 +9,7 @@ interface SimpleBlogPostCardProps {
   author: string
   description: string
   slug: string
-  image: string
+  image?: string | null
   featured?: boolean
   compact?: boolean
   gradientClass: string
@@ -29,6 +29,8 @@ export default function SimpleBlogPostCard({
   gradientClass,
   prefetch,
 }: SimpleBlogPostCardProps) {
+  const hasFeaturedImage = typeof image === "string" && image.trim().length > 0
+
   return (
     <Link
       href={`/blog/${slug}`}
@@ -38,7 +40,17 @@ export default function SimpleBlogPostCard({
       className="block h-full"
     >
       <article className="h-full overflow-hidden rounded-md border border-border/60 bg-card/30 backdrop-blur-sm flex flex-col transition-[transform,background-color] duration-200 hover:-translate-y-0.5 hover:bg-card/45">
-        <div className={cn("relative w-full aspect-[4/3] overflow-hidden", gradientClass)} />
+        <div className={cn("relative w-full aspect-[4/3] overflow-hidden", !hasFeaturedImage && gradientClass)}>
+          {hasFeaturedImage ? (
+            <img
+              src={image}
+              alt={`${title} featured image`}
+              loading="lazy"
+              decoding="async"
+              className="h-full w-full object-cover"
+            />
+          ) : null}
+        </div>
         <div className="flex flex-1 flex-col space-y-3 border-t border-border/60 p-5">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <span className="inline-flex items-center rounded-md border border-border/60 bg-muted/40 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">

--- a/docs/blog-content-architecture.md
+++ b/docs/blog-content-architecture.md
@@ -30,6 +30,8 @@ Each MDX file must define:
 | `image` | optional | Relative path for hero image + cards |
 | `h1Title`, `showHeroImage`, `openGraph`, `twitter`, `canonical` | optional | Overrides for layout & SEO |
 
+Blog cards render the frontmatter `image` when available. If `image` is omitted, cards automatically fall back to the post `gradientClass` for the preview frame background.
+
 `lib/mdx.tsx` automatically derives `categorySlug` from the `category` label by lowercasing and replacing non-alphanumeric characters with hyphens. Stick to meaningful labels; the slug keeps filters URL-safe.
 
 Open Graph behavior: if `openGraph.images` is present in frontmatter, those images are used for metadata. Otherwise the blog post falls back to the dynamic OG generator at `/api/og/blog/[slug]`, which uses `gradientClass` for the background. Add matching `twitter.images` if you want Twitter previews to use the same custom asset.


### PR DESCRIPTION
### Motivation
- Blog preview frames should display a post's authored featured image when available, and only use the gradient placeholder when no image is set.

### Description
- Updated `SimpleBlogPostCard` to accept an optional `image` prop and render the featured image inside the preview frame when present, otherwise apply the `gradientClass` as the background.
- Replaced hardcoded fallback image overrides at blog card call sites so cards can use the gradient fallback when `post.image` is absent (updated multiple pages and sections including blog index, related posts, latest posts, and several service pages).
- Switched from `next/image` usage (during dev) to a standard `img` for simpler local rendering in the preview frame and to avoid image host config complications in dev.
- Documented the card behavior in `docs/blog-content-architecture.md` so frontmatter expectations and fallback behavior are explicit.

### Testing
- Ran `pnpm lint` and the lint pass completed successfully.
- Ran `pnpm typecheck`; an initial run surfaced generated dev type artifacts, then after cleaning `.next` the typecheck completed successfully.
- Started the dev server with `pnpm dev` and captured a visual verification screenshot via Playwright; the screenshot artifact is available at `browser:/tmp/codex_browser_invocations/9b71c5651dee49f2/artifacts/artifacts/blog-featured-images.png`.
- A second automated Playwright attempt crashed the headless browser in this environment (SIGSEGV), which is an environment-level failure and not related to the change itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c008d1de88321ae2f2c1f92143649)