### PR TITLE
Fallback to gradient for missing blog featured images

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -31,6 +31,7 @@ Custom confirmation routes live in `app/thank-you/` and `app/analysis-thank-you/
 - Noindex routes should remain crawlable (meta `robots`), but **must be excluded** from the sitemap via `app/sitemap.ts`.
 - `/blog` filter/search views (`/blog?category=...`, `/blog?q=...`) are set to **noindex, follow** via `X-Robots-Tag` in `proxy.ts` so query-param URLs don’t pollute the index.
 - If a blog post `image` frontmatter uses an absolute Prism URL (e.g. `https://www.design-prism.com/...`), we normalize it for Next/Image. Prefer relative paths like `/api/og/...` or `/blog/...` for consistency.
+- Blog cards now validate relative `image` frontmatter paths against `public/` at read time. If the file is missing (or the value is empty/`null`/`undefined`), the card intentionally falls back to its configured gradient thumbnail so broken-image icons never render.
 - Keep `/api/og/` **allowed** in `app/robots.ts` if we use OG endpoints in metadata or structured data.
 - Prefer the shared JSON-LD helpers in `components/schema-markup.tsx` (`WebPageSchema`, `CollectionPageSchema`, `ItemListSchema`, `ServiceSchema`, `FAQSchema`, etc.).
 - Every indexable page must render a visible `<h1>` that matches the primary search intent.


### PR DESCRIPTION
### Motivation
- Prevent blog cards from rendering broken image icons when frontmatter `image` is missing, empty, or points to a non-existent public asset.
- Keep external and API-generated image URLs working while preferring the existing gradient thumbnail as a safe fallback for relative `public/` assets.

### Description
- Added image normalization and validation helpers in `lib/mdx-data.ts`: `INVALID_IMAGE_VALUES`, `isExternalImageUrl`, `isApiImageRoute`, `getPublicAssetPath`, and `resolveFrontmatterImage` to centralize frontmatter image handling.
- Resolve frontmatter `image` at read time via `resolveFrontmatterImage(...)` so invalid/blank-like values (`""`, `null`, `undefined`, `none`, `false`) return `undefined` and relative `/...` paths are checked against the `public/` directory before being used.
- Preserve absolute `http(s)` and `/api/...` image routes unchanged while logging missing asset warnings and falling back to the component gradient classes when images resolve to `undefined`.
- Documented the behavior in `docs/development-guide.md` under SEO/blog hygiene.

### Testing
- Ran `pnpm lint` which completed successfully with no lint regressions.
- Ran `pnpm typecheck` (TypeScript `tsc --noEmit`) which completed successfully with no type errors.
- Started the dev server and performed a visual verification via a Playwright screenshot of `/blog`; the page rendered and gradient placeholders were used for posts that referenced missing public assets, and a screenshot artifact was produced; Next.js logged unrelated Google Fonts TLS warnings in the dev environment but the fallback rendering behaved as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c08f4735c832184f298491a186a12)