### PR TITLE
Add default featured image fallback for blog posts

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -31,7 +31,7 @@ Custom confirmation routes live in `app/thank-you/` and `app/analysis-thank-you/
 - Noindex routes should remain crawlable (meta `robots`), but **must be excluded** from the sitemap via `app/sitemap.ts`.
 - `/blog` filter/search views (`/blog?category=...`, `/blog?q=...`) are set to **noindex, follow** via `X-Robots-Tag` in `proxy.ts` so query-param URLs don’t pollute the index.
 - If a blog post `image` frontmatter uses an absolute Prism URL (e.g. `https://www.design-prism.com/...`), we normalize it for Next/Image. Prefer relative paths like `/api/og/...` or `/blog/...` for consistency.
-- Blog cards now validate relative `image` frontmatter paths against `public/` at read time. If the file is missing (or the value is empty/`null`/`undefined`), the card intentionally falls back to its configured gradient thumbnail so broken-image icons never render.
+- Blog cards now validate relative `image` frontmatter paths against `public/` at read time. If the file is missing (or the value is empty/`null`/`undefined`), posts now fall back to the shared default featured image (`https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png`) instead of rendering a broken image.
 - Keep `/api/og/` **allowed** in `app/robots.ts` if we use OG endpoints in metadata or structured data.
 - Prefer the shared JSON-LD helpers in `components/schema-markup.tsx` (`WebPageSchema`, `CollectionPageSchema`, `ItemListSchema`, `ServiceSchema`, `FAQSchema`, etc.).
 - Every indexable page must render a visible `<h1>` that matches the primary search intent.

--- a/lib/mdx-data.ts
+++ b/lib/mdx-data.ts
@@ -29,6 +29,8 @@ export type BlogFrontmatter = {
 
 const BLOG_PATH = path.join(process.cwd(), "content", "blog")
 const PUBLIC_PATH = path.join(process.cwd(), "public")
+const DEFAULT_BLOG_FEATURED_IMAGE =
+  "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 
 const CODEX_REGEX = /\bcode?x\b/gi
 const DEFAULT_CATEGORY_SLUG = "general"
@@ -83,10 +85,10 @@ function getPublicAssetPath(imagePath: string) {
 }
 
 async function resolveFrontmatterImage(imageValue: unknown, slug: string): Promise<string | undefined> {
-  if (typeof imageValue !== "string") return undefined
+  if (typeof imageValue !== "string") return DEFAULT_BLOG_FEATURED_IMAGE
 
   const trimmedImage = imageValue.trim()
-  if (INVALID_IMAGE_VALUES.has(trimmedImage.toLowerCase())) return undefined
+  if (INVALID_IMAGE_VALUES.has(trimmedImage.toLowerCase())) return DEFAULT_BLOG_FEATURED_IMAGE
 
   if (isExternalImageUrl(trimmedImage) || isApiImageRoute(trimmedImage)) {
     return trimmedImage
@@ -103,9 +105,9 @@ async function resolveFrontmatterImage(imageValue: unknown, slug: string): Promi
     return trimmedImage
   } catch {
     console.warn(
-      `[MDXLib] Post "${slug}" references missing image "${trimmedImage}". Falling back to gradient placeholder.`,
+      `[MDXLib] Post "${slug}" references missing image "${trimmedImage}". Falling back to default featured image.`,
     )
-    return undefined
+    return DEFAULT_BLOG_FEATURED_IMAGE
   }
 }
 


### PR DESCRIPTION
## Summary
- added a shared `DEFAULT_BLOG_FEATURED_IMAGE` constant in `lib/mdx-data.ts`
- updated frontmatter image resolution so missing/invalid/non-string blog `image` values now fall back to `https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png`
- updated the warning log message for missing local image files to reflect the new default-image fallback behavior
- documented the new fallback behavior in `docs/development-guide.md`

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c0d775c808321849f1496b934d0b7)