### PR TITLE
Fix blog featured image fallback consistency

### DIFF
--- a/__tests__/mdx.test.ts
+++ b/__tests__/mdx.test.ts
@@ -1,9 +1,12 @@
 jest.mock('server-only', () => ({}), { virtual: true })
 import BlogPostPage from '../app/blog/[slug]/page'
 import { getPost } from '../lib/mdx-data'
+import { DEFAULT_BLOG_FEATURED_IMAGE } from '../lib/blog-images'
 
 jest.mock('next/navigation', () => ({
-  notFound: jest.fn(() => { throw new Error('NEXT_NOT_FOUND') })
+  notFound: jest.fn(() => {
+    throw new Error('NEXT_NOT_FOUND')
+  }),
 }))
 
 describe('mdx helpers', () => {
@@ -14,7 +17,12 @@ describe('mdx helpers', () => {
 
   test('BlogPostPage throws NEXT_NOT_FOUND for missing slug', async () => {
     await expect(
-      BlogPostPage({ params: Promise.resolve({ slug: 'missing-post-slug' }) })
+      BlogPostPage({ params: Promise.resolve({ slug: 'missing-post-slug' }) }),
     ).rejects.toThrow('NEXT_NOT_FOUND')
+  })
+
+  test('falls back to the shared featured image when frontmatter image format is invalid', async () => {
+    const post = await getPost('vibe-coding-platform-foundation-2026')
+    expect(post?.frontmatter.image).toBe(DEFAULT_BLOG_FEATURED_IMAGE)
   })
 })

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,29 +1,34 @@
 import BlogPostLayout from '@/components/blog-post-layout'
-import BlogEmailSignup from "@/components/blog-email-signup"
-import { getAllPosts, getPost } from "@/lib/mdx-data"
-import { renderPost } from "@/lib/mdx"
-import { getMdxToc } from "@/lib/mdx-toc"
+import BlogEmailSignup from '@/components/blog-email-signup'
+import { getAllPosts, getPost } from '@/lib/mdx-data'
+import { renderPost } from '@/lib/mdx'
+import { getMdxToc } from '@/lib/mdx-toc'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 
-interface PageProps { params: Promise<{ slug: string }> }
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
 
 export const dynamicParams = false
 
 export async function generateStaticParams() {
   const posts = await getAllPosts()
   if (!posts) return []
-  return posts.map(post => ({ slug: post.slug }))
+  return posts.map((post) => ({ slug: post.slug }))
 }
 
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
   const { slug } = await params
   const post = await getPost(slug)
   if (!post) notFound()
   const { frontmatter } = post
-  
+
   // Prefer explicit OG images from frontmatter; fall back to dynamic generator.
-  const base = process.env.NEXT_PUBLIC_BASE_URL || 'https://www.design-prism.com'
+  const base =
+    process.env.NEXT_PUBLIC_BASE_URL || 'https://www.design-prism.com'
   const frontmatterOpenGraphImages = frontmatter.openGraph?.images
   const normalizedOpenGraphImages = Array.isArray(frontmatterOpenGraphImages)
     ? frontmatterOpenGraphImages
@@ -49,7 +54,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       ? [frontmatterTwitterImages]
       : []
   const openGraphImageUrls = normalizedOpenGraphImages
-    .map(image => (typeof image === "string" ? image : image?.url))
+    .map((image) => (typeof image === 'string' ? image : image?.url))
     .filter(Boolean)
   const twitterImages =
     normalizedTwitterImages.length > 0
@@ -57,7 +62,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       : openGraphImageUrls.length > 0
         ? openGraphImageUrls
         : [fallbackOgImage]
-  
+
   // Normalize canonical to www host regardless of frontmatter
   let canonicalUrl: string
   try {
@@ -70,8 +75,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   // Compute concise SEO title (avoid layout template and long strings)
   const maxTitleLength = 60
-  const rawTitle = frontmatter.title || "Blog post"
-  const brandSuffix = " | prism"
+  const rawTitle = frontmatter.title || 'Blog post'
+  const brandSuffix = ' | prism'
   const seoTitle =
     rawTitle.length + brandSuffix.length <= maxTitleLength
       ? `${rawTitle}${brandSuffix}`
@@ -121,9 +126,7 @@ export default async function BlogPostPage({ params }: PageProps) {
       description={frontmatter.description}
       date={frontmatter.date}
       category={frontmatter.category}
-      gradientClass={frontmatter.gradientClass}
       image={frontmatter.image}
-      showHeroImage={frontmatter.showHeroImage}
       openGraph={frontmatter.openGraph}
       canonical={frontmatter.canonical}
       relatedPosts={prioritized.slice(0, 3)}

--- a/components/blog-post-layout.tsx
+++ b/components/blog-post-layout.tsx
@@ -1,16 +1,18 @@
-import { BlogPostErrorBoundary } from "@/components/blog-error-boundary"
-import BlogHeroMedia from "@/components/blog/BlogHeroMedia"
-import BlogScrollProgress from "@/components/blog/BlogScrollProgress"
-import GetStartedCTA from "@/components/GetStartedCTA"
-import Footer from "@/components/footer"
-import Navbar from "@/components/navbar"
-import BlogShareIcons from "@/components/blog/blog-share-icons"
-import BlogTableOfContents, { type BlogTocItem } from "@/components/blog/BlogTableOfContents"
-import { BlogPostSchema, HowToSchema } from "@/components/schema-markup"
-import SimpleBlogPostCard from "@/components/simple-blog-post-card"
-import Breadcrumbs from "@/components/breadcrumbs"
-import { cn } from "@/lib/utils"
-import { toAbsoluteUrl } from "@/lib/url"
+import { BlogPostErrorBoundary } from '@/components/blog-error-boundary'
+import BlogHeroMedia from '@/components/blog/BlogHeroMedia'
+import BlogScrollProgress from '@/components/blog/BlogScrollProgress'
+import GetStartedCTA from '@/components/GetStartedCTA'
+import Footer from '@/components/footer'
+import Navbar from '@/components/navbar'
+import BlogShareIcons from '@/components/blog/blog-share-icons'
+import BlogTableOfContents, {
+  type BlogTocItem,
+} from '@/components/blog/BlogTableOfContents'
+import { BlogPostSchema, HowToSchema } from '@/components/schema-markup'
+import SimpleBlogPostCard from '@/components/simple-blog-post-card'
+import Breadcrumbs from '@/components/breadcrumbs'
+import { cn } from '@/lib/utils'
+import { toAbsoluteUrl } from '@/lib/url'
 
 interface Props {
   children: React.ReactNode
@@ -21,9 +23,7 @@ interface Props {
   description: string
   date: string
   category: string
-  gradientClass?: string
   image?: string
-  showHeroImage?: boolean
   openGraph?: {
     type?: string
     title?: string
@@ -66,22 +66,19 @@ export default function BlogPostLayout({
   description,
   date,
   category,
-  gradientClass,
   image,
-  showHeroImage = true,
   openGraph,
   canonical,
   relatedPosts = [],
   toc = [],
   howTo,
 }: Props) {
-  const effectiveGradient = gradientClass || "bg-gradient-to-br from-indigo-300/30 via-purple-300/30 to-pink-300/30"
-  const effectiveImageUrl = image ? toAbsoluteUrl(image) : toAbsoluteUrl("/prism-opengraph.png")
+  const effectiveImageUrl = image
+    ? toAbsoluteUrl(image)
+    : toAbsoluteUrl('/prism-opengraph.png')
 
   const shareUrl =
-    openGraph?.url ||
-    canonical ||
-    `https://www.design-prism.com/blog/${slug}`
+    openGraph?.url || canonical || `https://www.design-prism.com/blog/${slug}`
   const hasToc = toc.length > 0
 
   return (
@@ -92,12 +89,12 @@ export default function BlogPostLayout({
       <main className="flex-1">
         <div className="w-full py-6 sm:py-8 md:py-10">
           <div className="container mx-auto px-4 sm:px-6">
-            <div className={cn("mx-auto", hasToc ? "max-w-6xl" : "max-w-3xl")}>
+            <div className={cn('mx-auto', hasToc ? 'max-w-6xl' : 'max-w-3xl')}>
               <div className="max-w-3xl">
                 <Breadcrumbs
                   items={[
-                    { name: "home", url: "/" },
-                    { name: "blog", url: "/blog" },
+                    { name: 'home', url: '/' },
+                    { name: 'blog', url: '/blog' },
                     { name: title, url: shareUrl },
                   ]}
                 />
@@ -105,25 +102,25 @@ export default function BlogPostLayout({
               <article>
                 <header className="relative mb-6 sm:mb-8">
                   <div className="max-w-3xl">
-                    <BlogHeroMedia
-                      title={title}
-                      image={image}
-                      gradientClass={effectiveGradient}
-                      showHeroImage={showHeroImage}
-                      slug={slug}
-                    />
+                    <BlogHeroMedia title={title} image={image} slug={slug} />
                     <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-muted-foreground sm:text-sm">
                       <span className="inline-block rounded-md border border-border/60 bg-muted/30 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/90">
                         {category}
                       </span>
                       <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                         <time dateTime={new Date(date).toISOString()}>
-                          {new Intl.DateTimeFormat(undefined, { year: 'numeric', month: 'short', day: 'numeric' }).format(new Date(date))}
+                          {new Intl.DateTimeFormat(undefined, {
+                            year: 'numeric',
+                            month: 'short',
+                            day: 'numeric',
+                          }).format(new Date(date))}
                         </time>
                         <span className="text-border/70" aria-hidden>
                           &middot;
                         </span>
-                        <span className="font-medium text-foreground/80 normal-case">By {author}</span>
+                        <span className="font-medium text-foreground/80 normal-case">
+                          By {author}
+                        </span>
                       </div>
                     </div>
                     <h1 className="blog-post-title text-balance">
@@ -146,9 +143,7 @@ export default function BlogPostLayout({
                     <div className="order-2 lg:order-1 min-w-0">
                       <div className="max-w-3xl">
                         <BlogPostErrorBoundary>
-                          <div className="prose-blog">
-                            {children}
-                          </div>
+                          <div className="prose-blog">{children}</div>
                         </BlogPostErrorBoundary>
                       </div>
                     </div>
@@ -156,9 +151,7 @@ export default function BlogPostLayout({
                 ) : (
                   <div className="max-w-3xl">
                     <BlogPostErrorBoundary>
-                      <div className="prose-blog">
-                        {children}
-                      </div>
+                      <div className="prose-blog">{children}</div>
                     </BlogPostErrorBoundary>
                   </div>
                 )}
@@ -166,25 +159,29 @@ export default function BlogPostLayout({
                 {relatedPosts.length > 0 && (
                   <section className="mt-16 rounded-2xl border border-border/60 bg-card/40 p-6 sm:p-8">
                     <div className="flex flex-col gap-2 mb-6">
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Keep learning</p>
-                      <h2 className="text-2xl font-bold tracking-tight">Related posts</h2>
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                        Keep learning
+                      </p>
+                      <h2 className="text-2xl font-bold tracking-tight">
+                        Related posts
+                      </h2>
                       <p className="text-sm text-muted-foreground">
                         More experiments and playbooks from the Prism team.
                       </p>
                     </div>
                     <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
                       {relatedPosts.map((related) => (
-                          <SimpleBlogPostCard
-                            key={related.slug}
-                            title={related.title}
-                            category={related.category}
-                            date={related.date}
-                            author={related.author}
-                            description={related.description}
-                            slug={related.slug}
-                            image={related.image}
-                            gradientClass={related.gradientClass}
-                            compact
+                        <SimpleBlogPostCard
+                          key={related.slug}
+                          title={related.title}
+                          category={related.category}
+                          date={related.date}
+                          author={related.author}
+                          description={related.description}
+                          slug={related.slug}
+                          image={related.image}
+                          gradientClass={related.gradientClass}
+                          compact
                         />
                       ))}
                     </div>
@@ -195,20 +192,38 @@ export default function BlogPostLayout({
                   <GetStartedCTA
                     heading={(() => {
                       const c = (category || '').toLowerCase()
-                      if (c.includes('ai') && c.includes('growth')) return 'ready to be agent‑ready?'
-                      if (c.includes('ai') && c.includes('marketing')) return 'turn ai exposure into booked revenue'
-                      if (c.includes('seo') || c.includes('search')) return 'recover organic traffic and convert it into leads'
-                      if (c.includes('design') || c.includes('product') || c.includes('development')) return 'ship a conversion‑focused site that moves metrics'
-                      if (c.includes('entrepreneur')) return 'get a focused plan and ship in days, not months'
+                      if (c.includes('ai') && c.includes('growth'))
+                        return 'ready to be agent‑ready?'
+                      if (c.includes('ai') && c.includes('marketing'))
+                        return 'turn ai exposure into booked revenue'
+                      if (c.includes('seo') || c.includes('search'))
+                        return 'recover organic traffic and convert it into leads'
+                      if (
+                        c.includes('design') ||
+                        c.includes('product') ||
+                        c.includes('development')
+                      )
+                        return 'ship a conversion‑focused site that moves metrics'
+                      if (c.includes('entrepreneur'))
+                        return 'get a focused plan and ship in days, not months'
                       return 'want help executing this playbook?'
                     })()}
                     description={(() => {
                       const c = (category || '').toLowerCase()
-                      if (c.includes('ai') && c.includes('growth')) return 'we’ll stand up your agent brief, wire the actions map, and ship your first 3 experiments in 30 days.'
-                      if (c.includes('ai') && c.includes('marketing')) return 'we help you build the context moat, get agent‑discoverable, and instrument bookings end‑to‑end.'
-                      if (c.includes('seo') || c.includes('search')) return 'ai has compressed clicks—let’s rebuild your funnel with task‑first pages, rich context, and interactive wins.'
-                      if (c.includes('design') || c.includes('product') || c.includes('development')) return 'from strategy to shipped ui: fast pages, clear messaging, and measured outcomes.'
-                      if (c.includes('business')) return 'we’ll help you choose one focus bet, design the experiments, and measure what matters.'
+                      if (c.includes('ai') && c.includes('growth'))
+                        return 'we’ll stand up your agent brief, wire the actions map, and ship your first 3 experiments in 30 days.'
+                      if (c.includes('ai') && c.includes('marketing'))
+                        return 'we help you build the context moat, get agent‑discoverable, and instrument bookings end‑to‑end.'
+                      if (c.includes('seo') || c.includes('search'))
+                        return 'ai has compressed clicks—let’s rebuild your funnel with task‑first pages, rich context, and interactive wins.'
+                      if (
+                        c.includes('design') ||
+                        c.includes('product') ||
+                        c.includes('development')
+                      )
+                        return 'from strategy to shipped ui: fast pages, clear messaging, and measured outcomes.'
+                      if (c.includes('business'))
+                        return 'we’ll help you choose one focus bet, design the experiments, and measure what matters.'
                       return 'work with prism to apply these steps to your brand—fast, focused, and measured.'
                     })()}
                     analyticsLabel={`blog_post_${slug}`}
@@ -225,11 +240,15 @@ export default function BlogPostLayout({
       <BlogPostSchema
         title={title}
         description={description}
-        url={openGraph?.url || canonical || `https://www.design-prism.com/blog/${slug}`}
+        url={
+          openGraph?.url ||
+          canonical ||
+          `https://www.design-prism.com/blog/${slug}`
+        }
         imageUrl={effectiveImageUrl}
         datePublished={openGraph?.publishedTime || date}
         dateModified={openGraph?.modifiedTime || date}
-        authorName={author || openGraph?.authors?.[0] || "prism"}
+        authorName={author || openGraph?.authors?.[0] || 'prism'}
       />
       {howTo ? (
         <HowToSchema

--- a/components/blog/BlogHeroMedia.tsx
+++ b/components/blog/BlogHeroMedia.tsx
@@ -1,30 +1,27 @@
-"use client"
+'use client'
 
-import { useState } from "react"
+import { useState } from 'react'
 
-import CoreImage from "@/components/core-image"
-import { cn } from "@/lib/utils"
-import { toLocalPathIfSameOrigin } from "@/lib/url"
+import CoreImage from '@/components/core-image'
+import { DEFAULT_BLOG_FEATURED_IMAGE } from '@/lib/blog-images'
+import { toLocalPathIfSameOrigin } from '@/lib/url'
 
 interface BlogHeroMediaProps {
   title: string
   image?: string
-  gradientClass: string
-  showHeroImage?: boolean
   slug: string
 }
 
 export default function BlogHeroMedia({
   title,
   image,
-  gradientClass,
-  showHeroImage = true,
   slug,
 }: BlogHeroMediaProps) {
   const [hasImageError, setHasImageError] = useState(false)
+  const featuredImage = image?.trim() || DEFAULT_BLOG_FEATURED_IMAGE
+  const effectiveSrc = toLocalPathIfSameOrigin(featuredImage)
 
-  if (showHeroImage && image && !hasImageError) {
-    const effectiveSrc = toLocalPathIfSameOrigin(image)
+  if (!hasImageError) {
     return (
       <div className="relative mb-6 overflow-hidden rounded-2xl border border-border/60 bg-card/20 shadow-sm shadow-black/40">
         <CoreImage
@@ -36,19 +33,34 @@ export default function BlogHeroMedia({
           sizes="(max-width: 1024px) 100vw, 896px"
           priority
           trackingId={`blog_hero_${slug}`}
-          onLoadError={() => setHasImageError(true)}
+          onLoadError={() => {
+            if (effectiveSrc !== DEFAULT_BLOG_FEATURED_IMAGE) {
+              setHasImageError(true)
+            }
+          }}
           customErrorHandling
         />
       </div>
     )
   }
 
-  return (
-    <div
-      className={cn(
-        "aspect-[16/9] sm:aspect-[21/9] relative mb-6 overflow-hidden rounded-2xl border border-border/60 bg-card/20 shadow-sm shadow-black/40",
-        gradientClass,
-      )}
-    />
-  )
+  if (hasImageError) {
+    return (
+      <div className="relative mb-6 overflow-hidden rounded-2xl border border-border/60 bg-card/20 shadow-sm shadow-black/40">
+        <CoreImage
+          src={DEFAULT_BLOG_FEATURED_IMAGE}
+          alt={title}
+          width={896}
+          height={504}
+          className="w-full h-full object-cover"
+          sizes="(max-width: 1024px) 100vw, 896px"
+          priority
+          trackingId={`blog_hero_${slug}`}
+          customErrorHandling
+        />
+      </div>
+    )
+  }
+
+  return null
 }

--- a/components/simple-blog-post-card.tsx
+++ b/components/simple-blog-post-card.tsx
@@ -1,6 +1,7 @@
-import { cn } from "@/lib/utils"
-import { ArrowRight } from "lucide-react"
-import Link from "next/link"
+import { cn } from '@/lib/utils'
+import { DEFAULT_BLOG_FEATURED_IMAGE } from '@/lib/blog-images'
+import { ArrowRight } from 'lucide-react'
+import Link from 'next/link'
 
 interface SimpleBlogPostCardProps {
   title: string
@@ -29,7 +30,10 @@ export default function SimpleBlogPostCard({
   gradientClass,
   prefetch,
 }: SimpleBlogPostCardProps) {
-  const hasFeaturedImage = typeof image === "string" && image.trim().length > 0
+  const featuredImage =
+    typeof image === 'string' && image.trim().length > 0
+      ? image
+      : DEFAULT_BLOG_FEATURED_IMAGE
 
   return (
     <Link
@@ -40,16 +44,19 @@ export default function SimpleBlogPostCard({
       className="block h-full"
     >
       <article className="h-full overflow-hidden rounded-md border border-border/60 bg-card/30 backdrop-blur-sm flex flex-col transition-[transform,background-color] duration-200 hover:-translate-y-0.5 hover:bg-card/45">
-        <div className={cn("relative w-full aspect-[4/3] overflow-hidden", !hasFeaturedImage && gradientClass)}>
-          {hasFeaturedImage ? (
-            <img
-              src={image}
-              alt={`${title} featured image`}
-              loading="lazy"
-              decoding="async"
-              className="h-full w-full object-cover"
-            />
-          ) : null}
+        <div
+          className={cn(
+            'relative w-full aspect-[4/3] overflow-hidden',
+            gradientClass,
+          )}
+        >
+          <img
+            src={featuredImage}
+            alt={`${title} featured image`}
+            loading="lazy"
+            decoding="async"
+            className="h-full w-full object-cover"
+          />
         </div>
         <div className="flex flex-1 flex-col space-y-3 border-t border-border/60 p-5">
           <div className="flex flex-wrap items-center justify-between gap-2">
@@ -58,12 +65,18 @@ export default function SimpleBlogPostCard({
             </span>
             <div className="flex flex-wrap items-center justify-end gap-x-1 gap-y-1 text-xs text-muted-foreground">
               <time dateTime={new Date(date).toISOString()}>
-                {new Intl.DateTimeFormat(undefined, { year: 'numeric', month: 'short', day: 'numeric' }).format(new Date(date))}
+                {new Intl.DateTimeFormat(undefined, {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                }).format(new Date(date))}
               </time>
               <span className="text-border" aria-hidden>
                 &middot;
               </span>
-              <span className="font-medium text-foreground/80 normal-case">By {author}</span>
+              <span className="font-medium text-foreground/80 normal-case">
+                By {author}
+              </span>
             </div>
           </div>
           <h3 className="blog-card-title text-balance text-foreground normal-case">
@@ -76,7 +89,11 @@ export default function SimpleBlogPostCard({
           )}
           <div className="flex items-center pt-1 text-xs font-semibold uppercase tracking-[0.12em] text-foreground">
             Read post
-            <ArrowRight className="ml-1 h-4 w-4" aria-hidden="true" focusable="false" />
+            <ArrowRight
+              className="ml-1 h-4 w-4"
+              aria-hidden="true"
+              focusable="false"
+            />
           </div>
         </div>
       </article>

--- a/docs/blog-content-architecture.md
+++ b/docs/blog-content-architecture.md
@@ -19,18 +19,18 @@ Use this document when adding posts or customizing the discovery experience.
 
 Each MDX file must define:
 
-| Field | Required | Notes |
-| --- | --- | --- |
-| `title` | ✅ | Used for metadata + card headings |
-| `author` | optional | Byline for cards + post header (defaults to "Prism Team") |
-| `description` | ✅ | Summary for cards, RSS, and SEO |
-| `date` | ✅ | ISO string (`YYYY-MM-DD`) |
-| `category` | ✅ | Free-form label; slug auto-generated |
-| `gradientClass` | ✅ | Tailwind gradient utilities for OG art |
-| `image` | optional | Relative path for hero image + cards |
-| `h1Title`, `showHeroImage`, `openGraph`, `twitter`, `canonical` | optional | Overrides for layout & SEO |
+| Field                                          | Required | Notes                                                     |
+| ---------------------------------------------- | -------- | --------------------------------------------------------- |
+| `title`                                        | ✅       | Used for metadata + card headings                         |
+| `author`                                       | optional | Byline for cards + post header (defaults to "Prism Team") |
+| `description`                                  | ✅       | Summary for cards, RSS, and SEO                           |
+| `date`                                         | ✅       | ISO string (`YYYY-MM-DD`)                                 |
+| `category`                                     | ✅       | Free-form label; slug auto-generated                      |
+| `gradientClass`                                | ✅       | Tailwind gradient utilities for OG art                    |
+| `image`                                        | optional | Relative path for hero image + cards                      |
+| `h1Title`, `openGraph`, `twitter`, `canonical` | optional | Overrides for layout & SEO                                |
 
-Blog cards render the frontmatter `image` when available. If `image` is omitted, cards automatically fall back to the post `gradientClass` for the preview frame background.
+Blog cards and post hero sections render the frontmatter `image` when available. If `image` is omitted or invalid, they fall back to the shared default featured image (`https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png`).
 
 `lib/mdx.tsx` automatically derives `categorySlug` from the `category` label by lowercasing and replacing non-alphanumeric characters with hyphens. Stick to meaningful labels; the slug keeps filters URL-safe.
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -3,62 +3,75 @@
 This guide highlights the workflows we lean on most often while iterating on the marketing site. Use it as the quick reference when shipping copy tweaks, adding new landing sections, or wiring forms.
 
 ## Local Development
+
 - Install deps with `pnpm install` (repo assumes pnpm).
 - Start the Next.js dev server with `pnpm dev`.
 - Run `pnpm lint` before committing so the shared Tailwind + ESLint rules stay consistent.
 - Run `pnpm test:visual` before merging changes that touch the UI of `/`, `/about`, or `/pricing` (screenshot-locked routes).
 
 ## Styling Pipeline
+
 - Tailwind v4 runs through the `@tailwindcss/postcss` plugin, with `@import "tailwindcss";` and `@config "../tailwind.config.cjs";` in `app/globals.css`.
 - To safelist utilities, use `@source inline(...)` in `app/globals.css` (the `safelist` config option is no longer supported).
 
 ## Linting
+
 - ESLint uses the flat config in `eslint.config.js` (Next 16 removed `next lint`).
 
 ## Formspree Integration
+
 All marketing forms live under `components/forms/` (Contact, Free Analysis, Get Started) and share the `useFormValidation` hook. The AI Website Launch form lives in `components/ai-website-launch/AiWebsiteLaunchForm.tsx` (embedded in `app/ai-website-launch/client-page.tsx`) and follows the same submission pattern (client-side `fetch`, `Accept: application/json`, and redirect to `/thank-you`).
 
 Key details:
+
 - Forms post to Formspree via `fetch` with `Accept: application/json`. On success we push the user to `/thank-you` or `/analysis-thank-you` so our custom screens always render.
 - Use the `_subject` hidden field for inbox filtering and `_gotcha` as the honeypot.
 - When adding a new Formspree endpoint, import `useFormValidation({ onValidSubmit })` and only navigate after the request returns `response.ok`.
 
 ## Thank-You Screens
+
 Custom confirmation routes live in `app/thank-you/` and `app/analysis-thank-you/`. Each page is a simple card layout (hero card, CTA card, contact info). If you add new flows, point them to one of these routes for consistency.
 
 ## SEO Hygiene
+
 - Use absolute canonicals (`https://www.design-prism.com/...`) for every indexable route.
 - Noindex routes should remain crawlable (meta `robots`), but **must be excluded** from the sitemap via `app/sitemap.ts`.
 - `/blog` filter/search views (`/blog?category=...`, `/blog?q=...`) are set to **noindex, follow** via `X-Robots-Tag` in `proxy.ts` so query-param URLs don’t pollute the index.
 - If a blog post `image` frontmatter uses an absolute Prism URL (e.g. `https://www.design-prism.com/...`), we normalize it for Next/Image. Prefer relative paths like `/api/og/...` or `/blog/...` for consistency.
-- Blog cards now validate relative `image` frontmatter paths against `public/` at read time. If the file is missing (or the value is empty/`null`/`undefined`), posts now fall back to the shared default featured image (`https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png`) instead of rendering a broken image.
+- Blog cards and post hero images now validate frontmatter `image` values at read time. If the file is missing, uses an invalid sentinel (`null`/`undefined`/empty), or points to a raster extension whose asset is actually SVG markup, posts now fall back to the shared default featured image (`https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png`) instead of rendering a broken image.
 - Keep `/api/og/` **allowed** in `app/robots.ts` if we use OG endpoints in metadata or structured data.
 - Prefer the shared JSON-LD helpers in `components/schema-markup.tsx` (`WebPageSchema`, `CollectionPageSchema`, `ItemListSchema`, `ServiceSchema`, `FAQSchema`, etc.).
 - Every indexable page must render a visible `<h1>` that matches the primary search intent.
 
 ### Analytics & Conversion Tracking
+
 - Global Google Analytics + Google Ads tagging happens in `app/layout.tsx`. Both IDs come from `lib/constants.ts` (`GA_MEASUREMENT_ID` and `GOOGLE_ADS_ID`), so set `NEXT_PUBLIC_GA_MEASUREMENT_ID` if you need to override the fallback GA property.
 - Any route-level conversion (e.g., `/thank-you`) should load its own `<Script>` that fires the relevant `gtag('event', 'conversion', { send_to: 'AW-…' })`. See `app/thank-you/page.tsx` for the exact snippet tied to `AW-11373090310/hBMrCMijk70bEIasjq8q`.
 - When building a new landing page with a Formspree form, make sure the success handler navigates to `/thank-you` so the Ads conversion snippet runs and the GA pageview records properly.
 
 ## Pricing Page Content
+
 - Pricing UI is in `app/pricing/client-page.tsx` with the hero modal split into `components/pricing/PricingHero.tsx`.
 - Hero copy, tier descriptions, "Website Use Cases", and the new handoff section are all co-located for easy edits.
 - When introducing a new section, wrap it with `RevealOnScroll` helpers for consistent motion.
 
 ## Free Analysis & Contact Pages
+
 - `/free-analysis` and `/contact` are intentionally minimal (hero, form card, CTA).
 - Copy updates happen directly in `app/free-analysis/page.tsx` and `app/contact/page.tsx`.
 - Both pages reuse the shared forms mentioned above, so field changes only need to happen once.
 
 ## CTA Routing
+
 Any CTA labeled “free analysis” should point to `/free-analysis`. When you add a new CTA, double-check the href so we don’t regress to `/get-started` accidentally.
 
 ## Typography & Casing
+
 - Do not enforce global lowercase transforms for site copy; preserve natural capitalization for readability.
 - Use Tailwind text-transform utilities only when a specific component intentionally needs stylistic casing.
 
 ## UI Components (shadcn/ui)
+
 The site uses shadcn/ui primitives under `components/ui/` (Tailwind + Radix + `cn()` helpers) with the `radix-vega` preset (neutral palette + subtle menu accent, Inter as `--font-sans`). Add new primitives via the CLI so we stay aligned with upstream.
 
 - Add a component: `pnpm dlx shadcn@latest add <component>`
@@ -69,11 +82,14 @@ The site uses shadcn/ui primitives under `components/ui/` (Tailwind + Radix + `c
 Form note: our marketing forms rely on native HTML5 validation via `useFormValidation` (`form.checkValidity()` + real `<input>/<select>/<textarea>`). Avoid swapping native `<select>`/checkbox controls for Radix equivalents unless you also preserve native form semantics and validation.
 
 ## Sticky Navigation Offsets
+
 The navbar dynamically sets a CSS variable (`--prism-header-height`) so other sticky UI can position itself below the full header stack (including case study breadcrumbs). Case study chapter menus also set `--prism-case-study-nav-height` via `useCaseStudyStickyNavHeight` (see `hooks/use-case-study-sticky-nav.ts`), and jump targets rely on `scroll-margin-top` for correct offsets when scrolling into view. The case study section nav now uses a scrollable pill row plus a mobile "jump to" sheet so all items stay reachable on small screens.
 
 ## Navbar Icon Hover Motion
+
 - Navbar icons animate and tint on hover via the `.nav-link` + `.nav-icon` classes in `components/navbar.tsx` and the motion rules in `app/globals.css`.
 - Keep hover effects transform-only (plus icon color) and subtle so text layout stays stable and reduced-motion preferences remain respected.
 
 ## Deployment
+
 Merges to `main` deploy automatically via Vercel. If you need a preview, open a PR – the CI pipeline will comment with the URL.

--- a/lib/blog-images.ts
+++ b/lib/blog-images.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_BLOG_FEATURED_IMAGE =
+  'https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png'


### PR DESCRIPTION
### Motivation
- Resolve conflicting image rules that caused broken or inconsistent featured images on blog cards and post hero sections. 
- Ensure both the card thumbnail and post hero always show the same featured image and fall back to a single shared default when frontmatter is missing or invalid. 
- Detect common authoring issues (e.g., files declared as raster images that are actually SVG markup) and avoid rendering broken assets.

### Description
- Centralized the default fallback into `lib/blog-images.ts` as `DEFAULT_BLOG_FEATURED_IMAGE` and wired callers to use it. 
- Hardened frontmatter image resolution in `lib/mdx-data.ts` by validating: missing/empty sentinel values, external/API routes, local `public/` existence, and mismatched image format (raster extension whose file contains SVG markup); invalid cases return the shared default image. 
- Made UI consistent: `components/simple-blog-post-card.tsx` always renders the resolved featured image (or the shared fallback) instead of conditionally showing a gradient frame; `components/blog/BlogHeroMedia.tsx` always prioritizes the resolved featured image and downgrades to the shared fallback on load failure. 
- Removed obsolete `showHeroImage` plumbing between page/layout/hero so cards and hero rendering share the same resolution path, added a regression test in `__tests__/mdx.test.ts`, and updated docs in `docs/development-guide.md` and `docs/blog-content-architecture.md` to reflect the new behavior.

### Testing
- Ran lint and typechecks with `pnpm lint && pnpm typecheck` which completed successfully. 
- Ran the focused regression test `pnpm test __tests__/mdx.test.ts` which passed and verifies a mismatched frontmatter image falls back to the shared default. 
- Ran the full test suite with `pnpm test`; the changes did not introduce failures but the run surfaced an existing unrelated failing assertion in `__tests__/hero-monthly-leads-pill.test.tsx` (failure pre-existed and is not caused by these image fixes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c0f4596cc832181d3a7ecd693fe99)