### PR TITLE
Replace featured images for pre-2026 blog posts

### DIFF
--- a/content/blog/adapting-small-business-ai-search-revolution-2025.mdx
+++ b/content/blog/adapting-small-business-ai-search-revolution-2025.mdx
@@ -3,7 +3,7 @@ title: "adapting your small business to the ai search revolution: reclaim your t
 description: "learn practical ai-first strategies to help your small business thrive as ai search features change how customers find you online."
 date: "2025-07-17"
 category: "appear in ai search"
-image: "/blog/ai-search-revolution-small-business.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-purple-300/30 via-blue-300/30 to-cyan-300/30"
 openGraph:
   title: "adapting your small business to the ai search revolution"

--- a/content/blog/ai-agents-agentic-commerce-local-business.mdx
+++ b/content/blog/ai-agents-agentic-commerce-local-business.mdx
@@ -3,7 +3,7 @@ title: "the next big shift in online marketing: why ai agents will change how cu
 description: "explore how ai agents, instant checkout, and agentic commerce reshape discovery, trust, and conversions for local businesses—and how to get agent-ready."
 date: "2025-09-29"
 category: "AI & Growth"
-image: "/blog/chatgpt-agent-small-business.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-indigo-300/30 via-blue-300/30 to-cyan-300/30"
 showHeroImage: false
 openGraph:

--- a/content/blog/ai-effortlessly-welcome-more-patients-dental-practice.mdx
+++ b/content/blog/ai-effortlessly-welcome-more-patients-dental-practice.mdx
@@ -3,7 +3,7 @@ title: "still relying on word-of-mouth? how ai can effortlessly welcome more pat
 description: "discover how ai tools like chatbots, smart advertising, and seo can help your dental practice attract more new patients without technical expertise."
 date: "2025-06-01"
 category: "ai & marketing"
-image: "/blog/ai-dental-patient-growth.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-pink-300/30 via-purple-300/30 to-indigo-300/30"
 openGraph:
   title: "still relying on word-of-mouth? how ai can effortlessly welcome more patients to your dental practice"

--- a/content/blog/ai-search-for-dental-practice.mdx
+++ b/content/blog/ai-search-for-dental-practice.mdx
@@ -4,7 +4,7 @@ h1Title: "ai search for dental practice: how to show up in ai overviews + assist
 description: "a dentist-focused, step-by-step guide to win visibility in google ai overviews, chat-based assistants, and maps—without doorway pages or keyword stuffing."
 date: "2025-12-12"
 category: "appear in ai search"
-image: "/blog/ai-dental-patient-growth.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-sky-300/30 via-emerald-300/30 to-indigo-300/30"
 openGraph:
   title: "ai search for dental practice: how to show up in ai overviews + assistants"

--- a/content/blog/breaking-free-education-psyop.mdx
+++ b/content/blog/breaking-free-education-psyop.mdx
@@ -3,7 +3,7 @@ title: "breaking free from the education psyop: why the system wants you small"
 description: "the education system isn't broken—it's working exactly as designed. here's how i broke free from the compliance machine and why you should too."
 date: "2025-07-24"
 category: "Motivation & Entrepreneurship"
-image: "/blog/education-psyop-break-free.webp"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-blue-300/30 via-purple-300/30 to-indigo-300/30"
 openGraph:
   title: "breaking free from the education psyop: why the system wants you small"

--- a/content/blog/build-ecommerce-store-20-minutes-ai.mdx
+++ b/content/blog/build-ecommerce-store-20-minutes-ai.mdx
@@ -3,7 +3,7 @@ title: "how to build a complete e-commerce store in 20 minutes with ai"
 description: "use lovable + shopify to design, populate, and launch a fully working storefront without touching code."
 date: "2025-11-08"
 category: "AI & Development"
-image: "/api/og/blog/build-ecommerce-store-20-minutes-ai"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-sky-200/40 via-indigo-200/40 to-emerald-200/40"
 openGraph:
   title: "how to build a complete e-commerce store in 20 minutes with ai"

--- a/content/blog/built-animated-game-with-ai.mdx
+++ b/content/blog/built-animated-game-with-ai.mdx
@@ -3,7 +3,7 @@ title: "i built a fully animated game with an ai in minutes-here's what i learne
 description: "a first-hand account of building a cookie clicker clone with claude code and what it reveals about agentic software development."
 date: "2025-06-10"
 category: "ai powered web development"
-image: "/blog/claude-code-game-dev.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-green-300/30 via-blue-300/30 to-purple-300/30"
 openGraph:
   title: "i built a fully animated game with an ai in minutes-here's what i learned"

--- a/content/blog/business-visibility-chatgpt.mdx
+++ b/content/blog/business-visibility-chatgpt.mdx
@@ -3,7 +3,7 @@ title: "how to rank higher in ai search: a live experiment"
 description: "enzo from prism conducts a live experiment on ranking in ai search (chatgpt, gemini, grock, perplexity) and shares key takeaways for businesses."
 date: "2025-06-08"
 category: "appear in ai search"
-image: "/blog/ai-search-ranking-experiment.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-purple-300/30 via-pink-300/30 to-red-300/30"
 openGraph:
   title: "how to rank higher in ai search: a live experiment | prism"

--- a/content/blog/chatgpt-agent-growing-small-businesses.mdx
+++ b/content/blog/chatgpt-agent-growing-small-businesses.mdx
@@ -3,7 +3,7 @@ title: "chatgpt agent for growing small businesses: a game-changer for brick-and
 description: "discover how chatgpt's agent mode can streamline small-business operations, plus a comparison to perplexity's comet and why agents matter."
 date: "2025-07-26"
 category: "AI & Automation"
-image: "/blog/chatgpt-agent-small-business.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-green-300/30 via-blue-300/30 to-purple-300/30"
 openGraph:
   title: "chatgpt agent for growing small businesses: a game-changer"

--- a/content/blog/content-that-converts-give-away-secrets-sell-implementation.mdx
+++ b/content/blog/content-that-converts-give-away-secrets-sell-implementation.mdx
@@ -3,7 +3,7 @@ title: "content that converts: give away the secrets, sell the implementation"
 description: "your unique taste × one acute pain × free secrets → paid implementation. give away the playbook. sell the doing."
 date: "2025-08-11"
 category: "Content Strategy"
-image: "/api/og/blog/content-that-converts-give-away-secrets-sell-implementation"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-rose-300/30 via-amber-300/30 to-lime-300/30"
 openGraph:
   title: "content that converts: give away the secrets, sell the implementation"

--- a/content/blog/create-website-more-business-replit.mdx
+++ b/content/blog/create-website-more-business-replit.mdx
@@ -3,7 +3,7 @@ title: "create a website that gets you more business: a simple guide using repli
 description: "learn how to create a website that generates more business leads using replit, even if you're not a tech whiz. a simple guide for 2025."
 date: "2025-06-01"
 category: "ai powered web development"
-image: "/blog/replit-for-business-website.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-red-300/30 via-orange-300/30 to-yellow-300/30"
 openGraph:
   title: "create a website that gets you more business: a simple guide using replit"

--- a/content/blog/dental-practice-1-3m-swamp.mdx
+++ b/content/blog/dental-practice-1-3m-swamp.mdx
@@ -3,7 +3,7 @@ title: "the 1–3m swamp for dental practices"
 description: "the hardest part about scaling isn't finding opportunities — it's affording the people who can execute them."
 date: "2025-07-16"
 category: "Business & Leadership"
-image: "/blog/dental-practice-swamp.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-teal-300/30 via-blue-300/30 to-indigo-300/30"
 openGraph:
   title: "the 1–3m swamp for dental practices"

--- a/content/blog/dental-practice-rank-higher-google-search.mdx
+++ b/content/blog/dental-practice-rank-higher-google-search.mdx
@@ -4,7 +4,7 @@ h1Title: "dental practice rank higher in google search: a dentist checklist"
 description: "a step-by-step checklist to rank a dental practice higher in google search and maps with listings, reviews, service pages, and iteration."
 date: "2025-12-12"
 category: "seo"
-image: "/blog/ai-dental-patient-growth.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-emerald-300/30 via-sky-300/30 to-indigo-300/30"
 openGraph:
   title: "dental practice rank higher in google search: a dentist checklist"

--- a/content/blog/dental-seo-guide.mdx
+++ b/content/blog/dental-seo-guide.mdx
@@ -4,7 +4,7 @@ h1Title: "dental seo: the practical guide for dentists (maps + organic)"
 description: "a dentist-first dental seo guide: how maps + organic rankings work, what to fix first, and a 30-day plan to earn more calls and bookings."
 date: "2025-12-14"
 category: "seo"
-image: "/blog/ai-dental-patient-growth.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-emerald-300/30 via-sky-300/30 to-indigo-300/30"
 openGraph:
   title: "dental seo: the practical guide for dentists (maps + organic)"

--- a/content/blog/dentist-website-design-checklist.mdx
+++ b/content/blog/dentist-website-design-checklist.mdx
@@ -4,7 +4,7 @@ h1Title: "dentist website design checklist for higher conversions in 2026"
 description: "dentist website design checklist: must-have pages, trust signals, and seo + performance basics that help patients book."
 date: "2025-12-12"
 category: "website"
-image: "/blog/ai-dental-patient-growth.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-cyan-300/30 via-blue-300/30 to-indigo-300/30"
 openGraph:
   title: "dentist website design checklist (what converts in 2026)"

--- a/content/blog/design-is-the-moat-in-the-ai-era-5-lessons-from-figma-revenue-2025.mdx
+++ b/content/blog/design-is-the-moat-in-the-ai-era-5-lessons-from-figma-revenue-2025.mdx
@@ -3,7 +3,7 @@ title: "design is the moat in the ai era | 5 revenue lessons"
 description: "ai made building easy. design is now the moat. five battle-tested lessons to ship faster, convert better, and grow revenue—backed by prism’s playbook."
 date: "2025-08-08"
 category: "Design & Product"
-image: "/api/og/blog/design-is-the-moat-in-the-ai-era-5-lessons-from-figma-revenue-2025"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-indigo-300/30 via-purple-300/30 to-sky-300/30"
 openGraph:
   title: "design is the moat in the ai era: 5 lessons from figma—and how to turn them into revenue (2025)"

--- a/content/blog/download-website-images-httrack.mdx
+++ b/content/blog/download-website-images-httrack.mdx
@@ -3,7 +3,7 @@ title: "how to download all the images from any website using httrack"
 description: "mirror a site with httrack and pull every image locally for research, backups, or reference without manual saves."
 date: "2025-11-05"
 category: "web ops & tooling"
-image: "/api/og/blog/download-website-images-httrack"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-slate-200/40 via-blue-200/40 to-emerald-200/40"
 openGraph:
   title: "how to download all the images from any website using httrack"

--- a/content/blog/embracing-underdog-advantage-ai-growth-2025.mdx
+++ b/content/blog/embracing-underdog-advantage-ai-growth-2025.mdx
@@ -3,7 +3,7 @@ title: "embracing the underdog advantage: how ai can supercharge growth for star
 description: "how underdogs can use ai to accelerate growth—lessons from alex hormozi and practical moves for startups and local practices."
 date: "2025-07-26"
 category: "Business & AI"
-image: "/blog/underdog-advantage-ai-growth.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-violet-300/30 via-fuchsia-300/30 to-orange-300/30"
 openGraph:
   title: "embracing the underdog advantage: how ai can supercharge growth for startups, healthcare practices, and brands in 2025"

--- a/content/blog/facebook-ads-for-dentists-playbook.mdx
+++ b/content/blog/facebook-ads-for-dentists-playbook.mdx
@@ -4,7 +4,7 @@ h1Title: "facebook ads for dentists: the 30-day playbook"
 description: "a 30-day playbook for facebook ads for dentists: offer-first campaigns, creative, lead forms vs landing pages, and call tracking."
 date: "2025-12-12"
 category: "ads"
-image: "/blog/ai-dental-patient-growth.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-blue-300/30 via-violet-300/30 to-rose-300/30"
 openGraph:
   title: "facebook ads for dentists: the 30-day playbook"

--- a/content/blog/founders-playbook-ai-era.mdx
+++ b/content/blog/founders-playbook-ai-era.mdx
@@ -3,7 +3,7 @@ title: "the founder's playbook for the ai era: timeless wisdom from 27 entrepren
 description: "the age of ai is upon us. discover timeless principles from 27 legendary entrepreneurs that provide a powerful framework for thriving in the ai revolution."
 date: "2025-06-10"
 category: "AI & Marketing"
-image: "/blog/founders-ai-playbook.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-blue-300/30 via-purple-300/30 to-pink-300/30"
 openGraph:
   title: "the founder's playbook for the ai era: timeless wisdom from 27 entrepreneurs"

--- a/content/blog/from-6-impressions-to-hundreds-seo-journey.mdx
+++ b/content/blog/from-6-impressions-to-hundreds-seo-journey.mdx
@@ -3,7 +3,7 @@ title: "from 6 impressions a day to hundreds: what it really takes to win with s
 description: "the real 3-year seo journey prism took to go from near-zero traffic to hundreds of daily impressions—and how to copy it."
 date: "2025-12-08"
 category: "seo"
-image: "/api/og/blog/from-6-impressions-to-hundreds-seo-journey"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-amber-200/30 via-emerald-200/30 to-sky-300/30"
 canonical: "https://www.design-prism.com/blog/from-6-impressions-to-hundreds-seo-journey"
 openGraph:

--- a/content/blog/from-broken-to-beautiful-dental-website-transformation.mdx
+++ b/content/blog/from-broken-to-beautiful-dental-website-transformation.mdx
@@ -3,7 +3,7 @@ title: "from broken to beautiful: the complete website transformation of a denta
 description: "see how prism rebuilt a broken dental wordpress site into a high-performing, lovable + codex powered experience that converts."
 date: "2025-10-27"
 category: "AI & Dentistry"
-image: "/api/og/blog/from-broken-to-beautiful-dental-website-transformation"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-amber-300/30 via-rose-300/30 to-emerald-300/30"
 openGraph:
   title: "from broken to beautiful: the complete website transformation of a dental practice"

--- a/content/blog/from-one-video-to-seo-flywheel.mdx
+++ b/content/blog/from-one-video-to-seo-flywheel.mdx
@@ -4,7 +4,7 @@ author: "Enzo Sison"
 date: "2025-06-11"
 description: "how i turned a single youtube video into a complete content strategy in one afternoon."
 category: "seo"
-image: "/blog/from-one-video-to-seo-flywheel.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-rose-300/30 via-amber-200/30 to-lime-200/30"
 openGraph:
   title: "from one video to a full seo flywheel"

--- a/content/blog/future-of-seo-ai-search.mdx
+++ b/content/blog/future-of-seo-ai-search.mdx
@@ -3,7 +3,7 @@ title: "the future of seo is here: an actionable checklist for ai search"
 description: "learn how to future-proof your website with this actionable seo checklist built for the age of ai-powered search."
 date: "2025-06-11"
 category: "seo"
-image: "/blog/future-of-seo-ai-search.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-emerald-300/30 via-sky-300/30 to-indigo-300/30"
 openGraph:
   title: "the future of seo is here: an actionable checklist for ai search"

--- a/content/blog/generate-thousands-leads-without-more-ads.mdx
+++ b/content/blog/generate-thousands-leads-without-more-ads.mdx
@@ -3,7 +3,7 @@ title: "how to generate thousands of leads without spending more on ads"
 description: "turn cold traffic into qualified leads by offering value before you pitch."
 date: "2025-11-08"
 category: "Marketing & Growth"
-image: "/api/og/blog/generate-thousands-leads-without-more-ads"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-rose-200/40 via-orange-200/40 to-purple-200/40"
 openGraph:
   title: "how to generate thousands of leads without spending more on ads"

--- a/content/blog/google-ads-ai-smb-acquisition-playbook.mdx
+++ b/content/blog/google-ads-ai-smb-acquisition-playbook.mdx
@@ -3,7 +3,7 @@ title: "google ads + ai: a simple, profitable acquisition playbook for smbs"
 description: "launch a lean, testable paid engine in days—not months—and use ai to do the heavy lifting."
 date: "2025-09-01"
 category: "AI & Growth"
-image: "/api/og/blog/google-ads-ai-smb-acquisition-playbook"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-emerald-300/30 via-sky-300/30 to-indigo-300/30"
 openGraph:
   title: "google ads + ai: a simple, profitable acquisition playbook for smbs"

--- a/content/blog/google-ads-destination-not-working.mdx
+++ b/content/blog/google-ads-destination-not-working.mdx
@@ -4,7 +4,7 @@ h1Title: "fix the google ads destination not working error in minutes"
 description: "ads paused with a destination not working policy? allow adsbot, clear security blocks, and appeal the review in minutes."
 date: "2025-11-05"
 category: "google ads troubleshooting"
-image: "/api/og/blog/google-ads-destination-not-working"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-amber-200/40 via-rose-200/40 to-sky-200/40"
 openGraph:
   title: "google ads destination not working error: how to fix it fast"

--- a/content/blog/google-ads-health-personalized-warning.mdx
+++ b/content/blog/google-ads-health-personalized-warning.mdx
@@ -3,7 +3,7 @@ title: "google ads “health in personalized advertising” warning — what it 
 description: "see “eligible (limited)” with a health in personalized advertising notice? understand the policy, keep running, and stay compliant."
 date: "2025-11-05"
 category: "google ads troubleshooting"
-image: "/api/og/blog/google-ads-health-personalized-warning"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-emerald-200/40 via-sky-200/40 to-indigo-200/40"
 openGraph:
   title: "google ads “health in personalized advertising” warning — what it means and how to fix it"

--- a/content/blog/google-ai-search-revolution-small-business.mdx
+++ b/content/blog/google-ai-search-revolution-small-business.mdx
@@ -3,7 +3,7 @@ title: "how google's ai-powered search revolution is boosting leads for small br
 description: "discover how google's ai search features are helping local businesses get more qualified leads and foot traffic in 2025."
 date: "2025-07-24"
 category: "appear in ai search"
-image: "/blog/google-ai-search-local-business.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-blue-300/30 via-indigo-300/30 to-purple-300/30"
 openGraph:
   title: "google's ai-powered search revolution is boosting leads for small brick-and-mortar businesses"

--- a/content/blog/google-maps-visibility-playbook-2025.mdx
+++ b/content/blog/google-maps-visibility-playbook-2025.mdx
@@ -4,7 +4,7 @@ h1Title: "get your business visible on google maps: the complete 2025 checklist"
 description: "understand how relevance, proximity, and prominence drive google maps results—and follow a 2025 checklist to boost your local visibility."
 date: "2025-11-10"
 category: "local seo"
-image: "/api/og/blog/google-maps-visibility-playbook-2025"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-sky-300/30 via-emerald-300/30 to-indigo-300/30"
 openGraph:
   title: "google maps visibility checklist for local businesses (2025)"

--- a/content/blog/gpt-5-1-codex-test-dentist-website.mdx
+++ b/content/blog/gpt-5-1-codex-test-dentist-website.mdx
@@ -3,7 +3,7 @@ title: "gpt-5.1 codex test: can an ai model build a dentist website in one shot?
 description: "prism's no-hype benchmark of gpt-5.1 codex (high) building a multi-page dentist site: speed, ui quality, responsiveness, structure, and agency readiness."
 date: "2025-11-18"
 category: "AI & Dentistry"
-image: "/api/og/blog/gpt-5-1-codex-test-dentist-website"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-cyan-300/30 via-indigo-300/30 to-fuchsia-300/30"
 openGraph:
   title: "gpt-5.1 codex test: can an ai model build a dentist website in one shot?"

--- a/content/blog/gpt-5-2-vs-gpt-5-1-codex-max-dentist-website.mdx
+++ b/content/blog/gpt-5-2-vs-gpt-5-1-codex-max-dentist-website.mdx
@@ -3,7 +3,7 @@ title: "gpt‑5.2 vs gpt‑5.1 codex max: i one‑shotted a full dentist website
 description: "a real‑world empty‑repo one‑shot build comparing gpt‑5.2 vs gpt‑5.1 codex max on a full multi‑page dentist website."
 date: "2025-12-12"
 category: "AI & Dentistry"
-image: "/api/og/blog/gpt-5-2-vs-gpt-5-1-codex-max-dentist-website"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-amber-300/30 via-sky-300/30 to-violet-300/30"
 openGraph:
   title: "gpt‑5.2 vs gpt‑5.1 codex max: i one‑shotted a full dentist website from an empty repo"

--- a/content/blog/gpt5-two-levers-growth.mdx
+++ b/content/blog/gpt5-two-levers-growth.mdx
@@ -3,7 +3,7 @@ title: "gpt-5 and the two levers of growth: creativity on tap, execution at spee
 description: "most teams overcomplicate growth. in the gpt-5 era, the constraint isn’t what’s possible—it’s the loop speed between idea and result."
 date: "2025-08-11"
 category: "AI & Growth"
-image: "/10x-views-thumbnail.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-emerald-300/30 via-sky-300/30 to-indigo-300/30"
 openGraph:
   title: "gpt-5 and the two levers of growth: creativity on tap, execution at speed"

--- a/content/blog/great-content-collapse.mdx
+++ b/content/blog/great-content-collapse.mdx
@@ -3,7 +3,7 @@ title: "the great content collapse-and why prism clients will come out ahead"
 description: "ai answer boxes are siphoning traffic; here's how prism's post-click strategy keeps your brand visible and valuable."
 date: "2025-07-03"
 category: "AI & Marketing"
-image: "/blog/ai-digital-marketing.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-rose-300/30 via-amber-300/30 to-lime-300/30"
 openGraph:
   title: "the great content collapse-and why prism clients will come out ahead"

--- a/content/blog/how-to-choose-local-seo-agency.mdx
+++ b/content/blog/how-to-choose-local-seo-agency.mdx
@@ -4,7 +4,7 @@ h1Title: "how to choose a local seo agency: checklist + red flags"
 description: "a practical guide to hiring the right local seo agency: what to ask, what to avoid, and how to judge results beyond vanity rankings."
 date: "2025-12-14"
 category: "local seo"
-image: "/api/og/blog/how-to-choose-local-seo-agency"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-amber-200/30 via-emerald-200/30 to-sky-300/30"
 openGraph:
   title: "how to choose a local seo agency (checklist + red flags)"

--- a/content/blog/how-to-choose-seo-consultant-for-dentists.mdx
+++ b/content/blog/how-to-choose-seo-consultant-for-dentists.mdx
@@ -4,7 +4,7 @@ h1Title: "how to choose an seo consultant for dentists"
 description: "a practical checklist for hiring the right seo consultant for your dental practice—maps, on-page, technical seo, reviews, and reporting tied to calls."
 date: "2025-12-12"
 category: "seo"
-image: "/blog/ai-dental-patient-growth.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-emerald-300/30 via-sky-300/30 to-indigo-300/30"
 openGraph:
   title: "how to choose an seo consultant for dentists (checklist + questions)"

--- a/content/blog/how-to-connect-openai-codex-to-your-lovable-dev-website.mdx
+++ b/content/blog/how-to-connect-openai-codex-to-your-lovable-dev-website.mdx
@@ -3,7 +3,7 @@ title: "how to connect loveable.dev to openai codex"
 description: "step-by-step workflow to move a loveable.dev project into openai codex with github sync, internet prompts, and clean pull requests."
 date: "2025-10-26"
 category: "ai powered web development"
-image: "/api/og/blog/how-to-connect-openai-codex-to-your-lovable-dev-website"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-blue-300/30 via-indigo-300/30 to-slate-300/30"
 openGraph:
   title: "how to connect loveable.dev to openai codex"

--- a/content/blog/how-to-rank-1-chatgpt.mdx
+++ b/content/blog/how-to-rank-1-chatgpt.mdx
@@ -4,7 +4,7 @@ h1Title: "the smart way to rank #1 in chatgpt results"
 description: "deploy answer engine optimization (aeo) to earn citations inside chatgpt, perplexity, and other ai assistants with a focused 30-day plan."
 date: "2025-09-18"
 category: "appear in ai search"
-image: "/blog/ai-digital-marketing.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-sky-300/30 via-purple-300/30 to-blue-300/30"
 showHeroImage: false
 openGraph:

--- a/content/blog/how-we-supercharged-prisms-site-with-midjourney-video.mdx
+++ b/content/blog/how-we-supercharged-prisms-site-with-midjourney-video.mdx
@@ -3,7 +3,7 @@ title: "how we supercharged prism's site with midjourney video (and how you can,
 description: "how we used midjourney video to add motion to the prism homepage without slowing performance, plus a simple workflow."
 date: "2025-07-05"
 category: "ai & design"
-image: "/prism-opengraph.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-indigo-300/30 via-purple-300/30 to-sky-300/30"
 openGraph:
   title: "how we supercharged prism's site with midjourney video (and how you can, too)"

--- a/content/blog/impossible-seo-bug-claude-code.mdx
+++ b/content/blog/impossible-seo-bug-claude-code.mdx
@@ -3,7 +3,7 @@ title: 'how an "impossible" seo bug turned into a 20-minute win with claude code
 description: "the structured data issue that kept our site health stuck at 92%, how swapping models fixed it fast, and a founder-ready seo checklist."
 date: "2025-12-07"
 category: "seo"
-image: "https://www.design-prism.com/api/og/blog/impossible-seo-bug-claude-code"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-amber-300/30 via-rose-300/30 to-indigo-300/30"
 openGraph:
   title: 'how an "impossible" seo bug turned into a 20-minute win with claude code'

--- a/content/blog/inside-gpt5s-brain-system-prompt-secrets-first-movers.mdx
+++ b/content/blog/inside-gpt5s-brain-system-prompt-secrets-first-movers.mdx
@@ -4,7 +4,7 @@ h1Title: "System Prompt Secrets That Unlock GPT-5's Full Potential"
 description: "stop chatting. start speccing. a spec-first approach to gpt-5 with templates, failure modes, and a one-week rollout."
 date: "2025-08-12"
 category: "AI & Growth"
-image: "/blog/ai-digital-marketing.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-emerald-300/30 via-sky-300/30 to-indigo-300/30"
 openGraph:
   title: "inside gpt-5’s brain: system prompt secrets for first movers"

--- a/content/blog/lovable-ai-review-business-owners.mdx
+++ b/content/blog/lovable-ai-review-business-owners.mdx
@@ -4,7 +4,7 @@ h1Title: "is lovable ai worth it? an honest review for business owners"
 description: "prism founder enzo sison stress-tests lovable's latest release against replit, cursor, and vercel to see if it's ready for real client work."
 date: "2025-10-01"
 category: "AI & Growth"
-image: "/api/og/blog/lovable-ai-review-business-owners"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-slate-300/30 via-purple-300/30 to-rose-300/30"
 openGraph:
   title: "lovable ai review: honest thoughts for business owners"

--- a/content/blog/modern-reviews-strategy-2025.mdx
+++ b/content/blog/modern-reviews-strategy-2025.mdx
@@ -3,7 +3,7 @@ title: "modern reviews strategy: where to focus in 2025"
 description: "the five-platform playbook local businesses need to keep reviews driving visibility, credibility, and ai-ready trust in 2025."
 date: "2025-10-29"
 category: "Local Growth & Reputation"
-image: "/blog/ai-digital-marketing.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-blue-300/30 via-purple-300/30 to-sky-300/30"
 openGraph:
   title: "modern reviews strategy: where to focus in 2025"

--- a/content/blog/new-rules-of-visibility-ai-seo.mdx
+++ b/content/blog/new-rules-of-visibility-ai-seo.mdx
@@ -3,7 +3,7 @@ title: "the new rules of visibility: how ai is rewriting seo (and what it means 
 description: "learn how ai assistants like chatgpt, claude, and gemini decide what to surface—and how your business can stay visible with geo, clarity, and freshness."
 date: "2025-11-01"
 category: "appear in ai search"
-image: "/blog/chatgpt-business-visibility.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-emerald-300/30 via-sky-300/30 to-indigo-300/30"
 showHeroImage: false
 openGraph:

--- a/content/blog/prism-approach-small-business-growth.mdx
+++ b/content/blog/prism-approach-small-business-growth.mdx
@@ -3,7 +3,7 @@ title: "the prism approach to small business growth"
 description: "how prism helps local businesses get found, trusted, and chosen through ai-ready websites, paid ads, and optimized listings."
 date: "2025-12-08"
 category: "Local Growth Strategy"
-image: "/api/og/blog/prism-approach-small-business-growth"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-amber-300/30 via-sky-300/30 to-emerald-300/30"
 openGraph:
   title: "the prism approach to small business growth"

--- a/content/blog/prism-flywheel-skyrocket-brick-and-mortar-growth.mdx
+++ b/content/blog/prism-flywheel-skyrocket-brick-and-mortar-growth.mdx
@@ -3,7 +3,7 @@ title: "how the prism flywheel can skyrocket your brick-and-mortar business grow
 description: "discover how the prism flywheel system transforms your online presence into a lead-generating machine without the social media grind."
 date: "2025-07-24"
 category: "Content Marketing & SEO"
-image: "/blog/prism-flywheel-business-growth.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-orange-300/30 via-red-300/30 to-purple-300/30"
 openGraph:
   title: "how the prism flywheel can skyrocket your brick-and-mortar business growth"

--- a/content/blog/reusable-shadcn-codex-template.mdx
+++ b/content/blog/reusable-shadcn-codex-template.mdx
@@ -3,7 +3,7 @@ title: "build a reusable shadcn + codex design system for every future project"
 description: "ship a single shadcn/ui template that codex pulls into every workspace so you stop rebuilding buttons, forms, and charts from scratch."
 date: "2025-11-05"
 category: "ai powered web development"
-image: "/api/og/blog/reusable-shadcn-codex-template"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-indigo-200/40 via-sky-200/40 to-emerald-200/40"
 openGraph:
   title: "build a reusable shadcn + codex design system for every future project"

--- a/content/blog/revolutionize-small-business-ai-extract-old-website-content-grok-4.mdx
+++ b/content/blog/revolutionize-small-business-ai-extract-old-website-content-grok-4.mdx
@@ -3,7 +3,7 @@ title: "revolutionize your small business with ai: extract old website content i
 description: "learn how grok 4 helps small business owners extract and organize old website content, creating a practical content flywheel for growth."
 date: "2025-07-14"
 category: "ai & business"
-image: "/blog/revolutionize-small-business-ai.png"  # Placeholder; replace with actual image if available
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-blue-300/30 via-indigo-300/30 to-purple-300/30"
 openGraph:
   title: "revolutionize your small business with ai: extract old website content in minutes using grok 4"

--- a/content/blog/riding-the-ai-wave.mdx
+++ b/content/blog/riding-the-ai-wave.mdx
@@ -3,7 +3,7 @@ title: "riding the ai wave: how prism keeps your practice ahead of the curve"
 description: "prism's ai-driven stack lets your dental website self-upgrade, squash bugs, and iterate design faster than ever."
 date: "2024-07-03"
 category: "AI & Dentistry"
-image: "/blog/riding-the-ai-wave.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-teal-300/30 via-cyan-300/30 to-indigo-300/30"
 openGraph:
   title: "riding the ai wave: how prism keeps your practice ahead of the curve"

--- a/content/blog/seo-mystery-beverly-hills-dentist-traffic-from-china.mdx
+++ b/content/blog/seo-mystery-beverly-hills-dentist-traffic-from-china.mdx
@@ -3,7 +3,7 @@ title: "the seo mystery: why a beverly hills dentist was getting traffic from ch
 description: "a real seo detective case: a beverly hills dentist got most of their traffic from china—here’s how we traced it to old backlink spam and cleaned it up."
 date: "2025-12-16"
 category: "seo"
-image: "/api/og/blog/seo-mystery-beverly-hills-dentist-traffic-from-china"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-rose-300/30 via-amber-300/30 to-sky-300/30"
 showHeroImage: false
 openGraph:

--- a/content/blog/the-grind-that-builds-empires.mdx
+++ b/content/blog/the-grind-that-builds-empires.mdx
@@ -3,7 +3,7 @@ title: "the grind that builds empires: why your solitary sweat separates legends
 description: "discover why solitary effort and persistent grind separate legends from the average in sports and entrepreneurship."
 date: "2025-07-13"
 category: "Motivation & Entrepreneurship"
-image: "/blog/the-grind-that-builds-empires.webp"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-indigo-300/30 via-purple-300/30 to-sky-300/30"
 openGraph:
   title: "the grind that builds empires: why your solitary sweat separates legends from the pack"

--- a/content/blog/turning-your-website-into-an-ai-powered-seo-flywheel.mdx
+++ b/content/blog/turning-your-website-into-an-ai-powered-seo-flywheel.mdx
@@ -4,7 +4,7 @@ author: "Enzo Sison"
 date: "2025-12-04"
 description: "the strategy behind the video: how we combine ai, google search console, and clean architecture to build a compounding seo flywheel."
 category: "seo"
-image: "https://www.design-prism.com/api/og/blog/turning-your-website-into-an-ai-powered-seo-flywheel"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-amber-300/30 via-emerald-200/30 to-sky-200/30"
 openGraph:
   title: "turning your website into an ai-powered seo flywheel"

--- a/content/blog/unlocking-ai-potential-small-business-prompting-strategies-chatgpt-5.mdx
+++ b/content/blog/unlocking-ai-potential-small-business-prompting-strategies-chatgpt-5.mdx
@@ -4,7 +4,7 @@ author: "Prism Team"
 description: "evidence-based ai prompting strategies for 2025, plus how to use chatgpt-5 reasoning models to get real business results."
 date: "2025-08-07"
 category: "AI & Business Productivity"
-image: "/blog/ai-prompting-strategies.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-cyan-300/30 via-blue-300/30 to-purple-300/30"
 openGraph:
   title: "unlocking ai's potential for your small business: lessons from the latest prompting strategies"

--- a/content/blog/unlocking-smb-growth-hormozi-100m-leads.mdx
+++ b/content/blog/unlocking-smb-growth-hormozi-100m-leads.mdx
@@ -3,7 +3,7 @@ title: "unlocking smb growth: lessons from alex hormozi's $100m leads (and why a
 description: "discover how to flood your pipeline with eager buyers using alex hormozi's $100m leads framework combined with ai-powered lead generation systems for smbs."
 date: "2025-07-29"
 category: "Business & AI"
-image: "/prism-opengraph.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-purple-300/30 via-indigo-300/30 to-blue-300/30"
 openGraph:
   title: "unlocking smb growth: lessons from alex hormozi's $100m leads (and why ai is your secret weapon right now)"

--- a/content/blog/unlocking-smb-growth-hormozi-100m-offers.mdx
+++ b/content/blog/unlocking-smb-growth-hormozi-100m-offers.mdx
@@ -3,7 +3,7 @@ title: "unlocking smb growth: lessons from alex hormozi's $100m offers (and why 
 description: "how alex hormozi’s $100m offers framework applies to smbs, with ai-powered examples for dentists, ecommerce, and startups."
 date: "2025-07-26"
 category: "Business & AI"
-image: "/blog/6m-arr-playbook.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-orange-300/30 via-red-300/30 to-purple-300/30"
 openGraph:
   title: "unlocking smb growth: lessons from alex hormozi's $100m offers (and why ai is your secret weapon right now)"

--- a/content/blog/win-next-ai-distribution-wave-30-day-playbook.mdx
+++ b/content/blog/win-next-ai-distribution-wave-30-day-playbook.mdx
@@ -3,7 +3,7 @@ title: "win the next ai distribution wave: a 30-day, no-fluff playbook for found
 description: "be early to the next ai platform opening. build a context moat, get agent-discoverable, and ship 3 high-impact experiments in 30 days—before the window closes."
 date: "2025-08-17"
 category: "AI & Growth"
-image: "/api/og/blog/win-next-ai-distribution-wave-30-day-playbook"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-emerald-300/30 via-sky-300/30 to-indigo-300/30"
 openGraph:
   title: "win the next ai distribution wave: a 30-day playbook"

--- a/content/blog/winning-ai-search-game.mdx
+++ b/content/blog/winning-ai-search-game.mdx
@@ -3,7 +3,7 @@ title: "winning the ai search game: a deep dive into ranking higher and getting 
 description: "learn how to adapt your seo strategy for the ai search era with this comprehensive guide on ranking in chatgpt, gemini, and perplexity."
 date: "2025-06-19"
 category: "appear in ai search"
-image: "/blog/ai-search-optimization.png"
+image: "https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png"
 gradientClass: "bg-gradient-to-br from-purple-300/30 via-pink-300/30 to-orange-300/30"
 openGraph:
   title: "winning the ai search game: a deep dive into ranking higher and getting more leads"


### PR DESCRIPTION
### Motivation
- Pre-2026 blog posts were using inconsistent or low-quality featured images that rendered poorly, so the site needs a single reliable default to improve visual consistency and avoid broken thumbnails.
- Standardizing to the canonical shared asset also simplifies discovery and fallback behavior for Open Graph and card previews.

### Description
- Updated the frontmatter `image` field in 57 MDX files under `content/blog/` to use the Cloudinary asset `https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png`.
- Left `openGraph` metadata and other frontmatter fields intact so metadata generation and OG fallbacks continue to work as before.
- This change is editorial only (frontmatter updates) and does not modify runtime components or styling.

### Testing
- Verified every blog post dated before 2026 now has the new image URL using an inline verification script (`python - <<'PY' ...`) that checked `date < 2026` and the `image` frontmatter, and confirmed all affected files (57) were updated successfully.
- Ran the repository linter with `pnpm lint` and it completed successfully.
- Attempted an automated Playwright screenshot to validate the UI, but the Chromium process crashed in this environment (SIGSEGV), so no visual artifact could be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c156e97908321b8dbcab30f29cf99)