### PR TITLE
Date-based Open Graph images for blog posts (pre-2026 shared OG, 2026+ featured image)

### DIFF
--- a/__tests__/mdx.test.ts
+++ b/__tests__/mdx.test.ts
@@ -1,7 +1,7 @@
 jest.mock('server-only', () => ({}), { virtual: true })
-import BlogPostPage from '../app/blog/[slug]/page'
+import BlogPostPage, { generateMetadata } from '../app/blog/[slug]/page'
 import { getPost } from '../lib/mdx-data'
-import { DEFAULT_BLOG_FEATURED_IMAGE } from '../lib/blog-images'
+import { DEFAULT_BLOG_FEATURED_IMAGE, getBlogOpenGraphImage } from '../lib/blog-images'
 
 jest.mock('next/navigation', () => ({
   notFound: jest.fn(() => {
@@ -24,5 +24,53 @@ describe('mdx helpers', () => {
   test('falls back to the shared featured image when frontmatter image format is invalid', async () => {
     const post = await getPost('vibe-coding-platform-foundation-2026')
     expect(post?.frontmatter.image).toBe(DEFAULT_BLOG_FEATURED_IMAGE)
+  })
+
+  test('uses shared OG image for posts dated before 2026', () => {
+    const ogImage = getBlogOpenGraphImage(
+      '2025-12-31',
+      'https://example.com/featured.png',
+      'https://www.design-prism.com',
+    )
+
+    expect(ogImage).toBe(DEFAULT_BLOG_FEATURED_IMAGE)
+  })
+
+  test('uses featured image for posts dated during and after 2026', () => {
+    const ogImage = getBlogOpenGraphImage(
+      '2026-01-01',
+      '/blog/brand-strategy.png',
+      'https://www.design-prism.com',
+    )
+
+    expect(ogImage).toBe('https://www.design-prism.com/blog/brand-strategy.png')
+  })
+
+  test('generateMetadata sets OG image by post date rule', async () => {
+    const oldPostMetadata = await generateMetadata({
+      params: Promise.resolve({ slug: 'how-to-choose-local-seo-agency' }),
+    })
+
+    expect(oldPostMetadata.openGraph?.images).toEqual([
+      {
+        url: DEFAULT_BLOG_FEATURED_IMAGE,
+        width: 1200,
+        height: 630,
+        alt: 'how to choose a local seo agency (checklist + red flags)',
+      },
+    ])
+
+    const newPostMetadata = await generateMetadata({
+      params: Promise.resolve({ slug: 'openclaw-manus-codex-scaling-business' }),
+    })
+
+    expect(newPostMetadata.openGraph?.images).toEqual([
+      {
+        url: 'https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770782009/Skier_xzs8az.png',
+        width: 1200,
+        height: 630,
+        alt: 'openclaw, manus, and codex are scaling my business',
+      },
+    ])
   })
 })

--- a/docs/blog-content-architecture.md
+++ b/docs/blog-content-architecture.md
@@ -34,7 +34,7 @@ Blog cards and post hero sections render the frontmatter `image` when available.
 
 `lib/mdx.tsx` automatically derives `categorySlug` from the `category` label by lowercasing and replacing non-alphanumeric characters with hyphens. Stick to meaningful labels; the slug keeps filters URL-safe.
 
-Open Graph behavior: if `openGraph.images` is present in frontmatter, those images are used for metadata. Otherwise the blog post falls back to the dynamic OG generator at `/api/og/blog/[slug]`, which uses `gradientClass` for the background. Add matching `twitter.images` if you want Twitter previews to use the same custom asset.
+Open Graph behavior is date-based in `app/blog/[slug]/page.tsx`: posts before 2026 always use the shared Prism OG image (`https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png`), while posts in 2026 and later use each post’s resolved featured image (`frontmatter.image`). Twitter images still honor explicit `twitter.images` first, then `openGraph.images`, then the date-based OG fallback.
 
 Headings (H2/H3) are assigned stable anchor IDs during MDX rendering (`rehype-slug`), and `lib/mdx-toc.ts` parses the MDX source to build the table of contents.
 

--- a/lib/blog-images.ts
+++ b/lib/blog-images.ts
@@ -1,2 +1,39 @@
 export const DEFAULT_BLOG_FEATURED_IMAGE =
   'https://res.cloudinary.com/dhqpqfw6w/image/upload/v1770786137/Prism_rgeypo.png'
+
+const BLOG_OG_FEATURED_IMAGE_CUTOFF_YEAR = 2026
+
+function extractYearFromDate(dateValue: string): number | null {
+  if (!dateValue) return null
+
+  const isoYearMatch = dateValue.match(/^(\d{4})/)
+  if (isoYearMatch) {
+    return Number(isoYearMatch[1])
+  }
+
+  const parsedDate = new Date(dateValue)
+  const parsedYear = parsedDate.getUTCFullYear()
+  return Number.isNaN(parsedYear) ? null : parsedYear
+}
+
+function toAbsoluteImageUrl(imageUrl: string, baseUrl: string): string {
+  if (!imageUrl.startsWith('/')) return imageUrl
+
+  const base = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+  return `${base}${imageUrl}`
+}
+
+export function getBlogOpenGraphImage(
+  postDate: string,
+  featuredImage: string | undefined,
+  baseUrl: string,
+): string {
+  const year = extractYearFromDate(postDate)
+
+  if (year === null || year < BLOG_OG_FEATURED_IMAGE_CUTOFF_YEAR) {
+    return DEFAULT_BLOG_FEATURED_IMAGE
+  }
+
+  const resolvedFeaturedImage = featuredImage || DEFAULT_BLOG_FEATURED_IMAGE
+  return toAbsoluteImageUrl(resolvedFeaturedImage, baseUrl)
+}


### PR DESCRIPTION
### Motivation
- Ensure consistent Open Graph imagery: posts dated before 2026 must use the shared Prism OG image and posts in 2026+ should use the post's featured image. 
- Normalize relative featured image paths to absolute URLs so generated metadata is always a valid absolute image URL.

### Description
- Added `getBlogOpenGraphImage` in `lib/blog-images.ts` which enforces a `2026` cutoff year, extracts a year from frontmatter `date`, and converts relative image paths to absolute URLs using the site base URL.
- Updated `app/blog/[slug]/page.tsx` `generateMetadata` to use the date-based OG image for `openGraph.images` and to keep the existing Twitter-image precedence (`twitter.images` → `openGraph.images` URLs → date-based fallback).
- Added tests to `__tests__/mdx.test.ts` to verify the helper and the real `generateMetadata` outputs for pre-2026 and 2026+ posts and preserved existing fallback behavior for invalid assets.
- Updated documentation in `docs/blog-content-architecture.md` to describe the new date-based Open Graph behavior.

### Testing
- Ran the modified test suite with `pnpm test -- --runInBand __tests__/mdx.test.ts`; an expectation mismatch was fixed during development and the final test run passed (all tests in that file passed).
- Ran type checking with `pnpm typecheck` (calls `tsc --noEmit`) and it passed.
- Ran linting with `pnpm lint` (ESLint) and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c18a385c08321aaafef3e4e09387d)