### PR TITLE
Fix mobile overflow on Michael Njo podcast page

### DIFF
--- a/app/podcast/michael-njo/page.tsx
+++ b/app/podcast/michael-njo/page.tsx
@@ -182,7 +182,7 @@ export default function MichaelNjoPage() {
               "Life gives you moments that will either break you or make you stronger. My injury broke me physically--but
               it made me stronger in every other way. Dentistry gave me a career; mentorship gave me purpose."
             </p>
-            <div className="text-sm uppercase tracking-[0.3em] text-neutral-500">
+            <div className="text-sm uppercase tracking-[0.2em] text-neutral-500 [overflow-wrap:anywhere] sm:tracking-[0.3em]">
               Michael Njo DDS · Dentist · Mentor · Consultant · Educator
             </div>
             <div className="flex flex-wrap items-center gap-4 pt-4">
@@ -190,8 +190,9 @@ export default function MichaelNjoPage() {
                 href="https://practicetransitionsinstitute.com"
                 target="_blank"
                 rel="noopener noreferrer"
+                className="w-full sm:w-auto"
               >
-                <Button className="rounded-full bg-neutral-900 px-6 py-5 text-base text-white hover:bg-neutral-800">
+                <Button className="h-auto w-full max-w-full rounded-full bg-neutral-900 px-5 py-4 text-center text-sm leading-relaxed whitespace-normal break-words text-white hover:bg-neutral-800 sm:w-auto sm:px-6 sm:py-5 sm:text-base sm:whitespace-nowrap">
                   Visit Practice Transitions Institute
                   <ArrowUpRight className="h-5 w-5" />
                 </Button>

--- a/docs/pages-overview.md
+++ b/docs/pages-overview.md
@@ -41,6 +41,7 @@ Quick reference for the pages we edit most often.
 ## Podcast (`app/podcast/page.tsx`)
 - Podcast hub + recent episode preview cards.
 - Uses `PodcastSeriesSchema` plus `PodcastEpisodeSchema` (with nested `VideoObject` metadata). Keep episode publish dates, YouTube URLs, and thumbnails up to date so Video structured data stays valid.
+- Individual episode spotlights (for example `app/podcast/michael-njo/page.tsx`) should keep CTA buttons mobile-safe by allowing full-width wrapping on small screens so no horizontal scrolling is introduced in quote/CTA cards.
 
 ## Dental Website (`app/dental-website/page.tsx`)
 - Dentist-focused website page targeting “dentist website design”.


### PR DESCRIPTION
### Motivation
- Prevent horizontal scrolling on the episode spotlight (`/podcast/michael-njo`) by making CTA and attribution copy behave safely on small viewports.

### Description
- Update `app/podcast/michael-njo/page.tsx` to make the external CTA anchor/button mobile-friendly by adding `className="w-full sm:w-auto"` to the link and replacing the `Button` classes so it can be full-width, wrap text, and not force overflow on small screens.
- Allow aggressive wrapping for the uppercase attribution line by adding `[overflow-wrap:anywhere]` and reducing mobile letter-spacing (`tracking-[0.2em]` with `sm:tracking-[0.3em]`).
- Add a note to `docs/pages-overview.md` recommending episode spotlights keep CTA buttons mobile-safe to avoid horizontal scroll.

### Testing
- Ran `pnpm exec eslint app/podcast/michael-njo/page.tsx` and it completed without errors.
- Ran `pnpm typecheck` (`tsc --noEmit --skipLibCheck`) and it completed without errors.
- Performed an automated Playwright mobile check against `http://127.0.0.1:3000/podcast/michael-njo` at a 390×844 viewport and confirmed `documentElement.scrollWidth === clientWidth` (no horizontal overflow) and saved a full-page screenshot as an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69927dd8f7bc8321a7bcb1226af7c7de)