### PR TITLE
Add clean /go shortlinks + UTM attribution persistence

### DIFF
--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { getCampaignLink } from "@/lib/campaign-links"
+
+export const runtime = "edge"
+
+const RESERVED_PARAMS = new Set([
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+])
+
+function toAbsoluteUrl(input: string, req: NextRequest): URL {
+  if (input.startsWith("http://") || input.startsWith("https://")) {
+    return new URL(input)
+  }
+
+  return new URL(input.startsWith("/") ? input : `/${input}`, req.nextUrl.origin)
+}
+
+export function GET(req: NextRequest, context: { params: { slug: string } }) {
+  const link = getCampaignLink(context.params.slug)
+
+  if (!link) {
+    const fallback = new URL("/get-started", req.nextUrl.origin)
+    fallback.searchParams.set("utm_source", "shortlink")
+    fallback.searchParams.set("utm_medium", "redirect")
+    fallback.searchParams.set("utm_campaign", "unknown_slug")
+    fallback.searchParams.set("utm_content", context.params.slug)
+    return NextResponse.redirect(fallback, { status: 302 })
+  }
+
+  const target = toAbsoluteUrl(link.destination, req)
+
+  target.searchParams.set("utm_source", link.utmSource)
+  target.searchParams.set("utm_medium", link.utmMedium)
+  target.searchParams.set("utm_campaign", link.utmCampaign)
+
+  if (link.utmContent) target.searchParams.set("utm_content", link.utmContent)
+  if (link.utmTerm) target.searchParams.set("utm_term", link.utmTerm)
+
+  req.nextUrl.searchParams.forEach((value, key) => {
+    if (!RESERVED_PARAMS.has(key)) {
+      target.searchParams.set(key, value)
+    }
+  })
+
+  return NextResponse.redirect(target, { status: link.permanent ? 301 : 302 })
+}

--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -20,15 +20,16 @@ function toAbsoluteUrl(input: string, req: NextRequest): URL {
   return new URL(input.startsWith("/") ? input : `/${input}`, req.nextUrl.origin)
 }
 
-export function GET(req: NextRequest, context: { params: { slug: string } }) {
-  const link = getCampaignLink(context.params.slug)
+export async function GET(req: NextRequest, context: { params: Promise<{ slug: string }> }) {
+  const { slug } = await context.params
+  const link = getCampaignLink(slug)
 
   if (!link) {
     const fallback = new URL("/get-started", req.nextUrl.origin)
     fallback.searchParams.set("utm_source", "shortlink")
     fallback.searchParams.set("utm_medium", "redirect")
     fallback.searchParams.set("utm_campaign", "unknown_slug")
-    fallback.searchParams.set("utm_content", context.params.slug)
+    fallback.searchParams.set("utm_content", slug)
     return NextResponse.redirect(fallback, { status: 302 })
   }
 

--- a/docs/campaign-link-governance.md
+++ b/docs/campaign-link-governance.md
@@ -1,0 +1,25 @@
+# Campaign Link Governance
+
+Use this to keep attribution clean and avoid noisy GA data.
+
+## Funnel destination standards
+- Top-of-funnel social profile links (`ig-bio`, `tiktok-bio`): `/offers`
+- Thought-leadership/profile links (`x-profile`, `linkedin-profile`): `/proof`
+- Content distribution links (`yt-description`, `podcast-show-notes`, `newsletter`): content hubs (`/blog`, `/podcast`)
+- High-intent links (`email-signature`, partner, paid ads): `/get-started`
+
+## Naming rules
+- Slugs: short, lowercase, hyphen-separated, one intent per slug
+- UTM campaign: lowercase snake_case
+- Medium values only from allowlist: `social`, `email`, `referral`, `paid_social`, `paid_search`
+
+## Operating cadence
+- Add/update links in `lib/campaign-links.ts`
+- Run QA before shipping: `pnpm qa:campaign-links`
+- Weekly QA in CI/automation should alert on broken or mismatched redirects
+
+## Owner checklist before launch
+1. slug exists and is enabled
+2. destination matches campaign intent
+3. expected utm fields are present
+4. tested with final public link

--- a/docs/utm-shortlinks.md
+++ b/docs/utm-shortlinks.md
@@ -22,6 +22,19 @@ Use clean public links via `/go/:slug` while preserving attribution.
 - Use normalized mediums: `social`, `email`, `referral`, `paid_social`, `paid_search`.
 - Keep one intent per slug.
 
+## Current starter slug pack
+- `/go/ig-bio`
+- `/go/x-profile`
+- `/go/linkedin-profile`
+- `/go/tiktok-bio`
+- `/go/yt-description`
+- `/go/podcast-show-notes`
+- `/go/newsletter`
+- `/go/email-signature`
+- `/go/meta-ad-01`
+- `/go/google-ad-01`
+- `/go/partner-referral`
+
 ## Attribution persistence
 Client analytics stores campaign context in first-party localStorage (`prism_attribution_v1`) for 30 days, then enriches downstream events with:
 - current or stored `utm_*`

--- a/docs/utm-shortlinks.md
+++ b/docs/utm-shortlinks.md
@@ -23,17 +23,22 @@ Use clean public links via `/go/:slug` while preserving attribution.
 - Keep one intent per slug.
 
 ## Current starter slug pack
-- `/go/ig-bio`
-- `/go/x-profile`
-- `/go/linkedin-profile`
-- `/go/tiktok-bio`
-- `/go/yt-description`
-- `/go/podcast-show-notes`
-- `/go/newsletter`
-- `/go/email-signature`
-- `/go/meta-ad-01`
-- `/go/google-ad-01`
-- `/go/partner-referral`
+- `/go/ig-bio` -> `/offers`
+- `/go/x-profile` -> `/proof`
+- `/go/linkedin-profile` -> `/proof`
+- `/go/tiktok-bio` -> `/offers`
+- `/go/yt-description` -> `/blog`
+- `/go/podcast-show-notes` -> `/podcast`
+- `/go/newsletter` -> `/blog`
+- `/go/email-signature` -> `/get-started`
+- `/go/meta-ad-01` -> `/get-started`
+- `/go/google-ad-01` -> `/get-started`
+- `/go/partner-referral` -> `/get-started`
+
+## QA
+- Local/manual check: `pnpm qa:campaign-links`
+- Uses production by default (`https://prism-website-gamma.vercel.app`)
+- Override target: `BASE_URL=https://your-preview-url pnpm qa:campaign-links`
 
 ## Attribution persistence
 Client analytics stores campaign context in first-party localStorage (`prism_attribution_v1`) for 30 days, then enriches downstream events with:

--- a/docs/utm-shortlinks.md
+++ b/docs/utm-shortlinks.md
@@ -1,0 +1,29 @@
+# UTM + Shortlink System
+
+Use clean public links via `/go/:slug` while preserving attribution.
+
+## How it works
+- Public link: `https://www.design-prism.com/go/ig-bio`
+- Redirect target is defined in `lib/campaign-links.ts`
+- Route injects UTM params and redirects in a single hop.
+
+## Add a new campaign link
+1. Open `lib/campaign-links.ts`
+2. Add a new slug entry with:
+   - `destination`
+   - `utmSource`
+   - `utmMedium`
+   - `utmCampaign`
+   - optional `utmContent`, `utmTerm`
+3. Share only the clean `/go/<slug>` URL.
+
+## Conventions
+- Use lowercase snake_case for `utm_campaign`.
+- Use normalized mediums: `social`, `email`, `referral`, `paid_social`, `paid_search`.
+- Keep one intent per slug.
+
+## Attribution persistence
+Client analytics stores campaign context in first-party localStorage (`prism_attribution_v1`) for 30 days, then enriches downstream events with:
+- current or stored `utm_*`
+- `gclid`, `fbclid`, `msclkid`
+- first-touch fields (`first_touch_source`, `first_touch_medium`, `first_touch_campaign`, `first_touch_at`)

--- a/lib/campaign-links.ts
+++ b/lib/campaign-links.ts
@@ -11,6 +11,7 @@ export type CampaignLink = {
 }
 
 export const CAMPAIGN_LINKS: Record<string, CampaignLink> = {
+  // Social profiles
   "ig-bio": {
     slug: "ig-bio",
     destination: "/get-started",
@@ -29,15 +30,46 @@ export const CAMPAIGN_LINKS: Record<string, CampaignLink> = {
     utmContent: "profile_link",
     enabled: true,
   },
+  "linkedin-profile": {
+    slug: "linkedin-profile",
+    destination: "/get-started",
+    utmSource: "linkedin",
+    utmMedium: "social",
+    utmCampaign: "brand_profile",
+    utmContent: "profile_link",
+    enabled: true,
+  },
+  "tiktok-bio": {
+    slug: "tiktok-bio",
+    destination: "/get-started",
+    utmSource: "tiktok",
+    utmMedium: "social",
+    utmCampaign: "brand_profile",
+    utmContent: "bio_link",
+    enabled: true,
+  },
+
+  // Content distribution
   "yt-description": {
     slug: "yt-description",
-    destination: "/get-started",
+    destination: "/blog",
     utmSource: "youtube",
     utmMedium: "social",
     utmCampaign: "content_distribution",
     utmContent: "video_description",
     enabled: true,
   },
+  "podcast-show-notes": {
+    slug: "podcast-show-notes",
+    destination: "/podcast",
+    utmSource: "podcast",
+    utmMedium: "social",
+    utmCampaign: "content_distribution",
+    utmContent: "show_notes",
+    enabled: true,
+  },
+
+  // Email
   "newsletter": {
     slug: "newsletter",
     destination: "/blog",
@@ -47,12 +79,42 @@ export const CAMPAIGN_LINKS: Record<string, CampaignLink> = {
     utmContent: "weekly_digest",
     enabled: true,
   },
+  "email-signature": {
+    slug: "email-signature",
+    destination: "/get-started",
+    utmSource: "email",
+    utmMedium: "email",
+    utmCampaign: "email_signature",
+    utmContent: "founder_signature",
+    enabled: true,
+  },
+
+  // Paid + partner
+  "meta-ad-01": {
+    slug: "meta-ad-01",
+    destination: "/get-started",
+    utmSource: "meta",
+    utmMedium: "paid_social",
+    utmCampaign: "offer_test",
+    utmContent: "ad_variation_01",
+    enabled: true,
+  },
+  "google-ad-01": {
+    slug: "google-ad-01",
+    destination: "/get-started",
+    utmSource: "google",
+    utmMedium: "paid_search",
+    utmCampaign: "offer_test",
+    utmContent: "rsa_variation_01",
+    enabled: true,
+  },
   "partner-referral": {
     slug: "partner-referral",
     destination: "/get-started",
     utmSource: "partner",
     utmMedium: "referral",
     utmCampaign: "partner_referral",
+    utmContent: "network_intro",
     enabled: true,
   },
 }

--- a/lib/campaign-links.ts
+++ b/lib/campaign-links.ts
@@ -1,0 +1,65 @@
+export type CampaignLink = {
+  slug: string
+  destination: string
+  utmSource: string
+  utmMedium: string
+  utmCampaign: string
+  utmContent?: string
+  utmTerm?: string
+  permanent?: boolean
+  enabled?: boolean
+}
+
+export const CAMPAIGN_LINKS: Record<string, CampaignLink> = {
+  "ig-bio": {
+    slug: "ig-bio",
+    destination: "/get-started",
+    utmSource: "instagram",
+    utmMedium: "social",
+    utmCampaign: "brand_profile",
+    utmContent: "bio_link",
+    enabled: true,
+  },
+  "x-profile": {
+    slug: "x-profile",
+    destination: "/get-started",
+    utmSource: "x",
+    utmMedium: "social",
+    utmCampaign: "brand_profile",
+    utmContent: "profile_link",
+    enabled: true,
+  },
+  "yt-description": {
+    slug: "yt-description",
+    destination: "/get-started",
+    utmSource: "youtube",
+    utmMedium: "social",
+    utmCampaign: "content_distribution",
+    utmContent: "video_description",
+    enabled: true,
+  },
+  "newsletter": {
+    slug: "newsletter",
+    destination: "/blog",
+    utmSource: "email",
+    utmMedium: "email",
+    utmCampaign: "newsletter",
+    utmContent: "weekly_digest",
+    enabled: true,
+  },
+  "partner-referral": {
+    slug: "partner-referral",
+    destination: "/get-started",
+    utmSource: "partner",
+    utmMedium: "referral",
+    utmCampaign: "partner_referral",
+    enabled: true,
+  },
+}
+
+export function getCampaignLink(slug: string): CampaignLink | null {
+  const normalized = slug.trim().toLowerCase()
+  const entry = CAMPAIGN_LINKS[normalized]
+  if (!entry || entry.enabled === false) return null
+  return entry
+}

--- a/lib/campaign-links.ts
+++ b/lib/campaign-links.ts
@@ -14,7 +14,7 @@ export const CAMPAIGN_LINKS: Record<string, CampaignLink> = {
   // Social profiles
   "ig-bio": {
     slug: "ig-bio",
-    destination: "/get-started",
+    destination: "/offers",
     utmSource: "instagram",
     utmMedium: "social",
     utmCampaign: "brand_profile",
@@ -23,7 +23,7 @@ export const CAMPAIGN_LINKS: Record<string, CampaignLink> = {
   },
   "x-profile": {
     slug: "x-profile",
-    destination: "/get-started",
+    destination: "/proof",
     utmSource: "x",
     utmMedium: "social",
     utmCampaign: "brand_profile",
@@ -32,7 +32,7 @@ export const CAMPAIGN_LINKS: Record<string, CampaignLink> = {
   },
   "linkedin-profile": {
     slug: "linkedin-profile",
-    destination: "/get-started",
+    destination: "/proof",
     utmSource: "linkedin",
     utmMedium: "social",
     utmCampaign: "brand_profile",
@@ -41,7 +41,7 @@ export const CAMPAIGN_LINKS: Record<string, CampaignLink> = {
   },
   "tiktok-bio": {
     slug: "tiktok-bio",
-    destination: "/get-started",
+    destination: "/offers",
     utmSource: "tiktok",
     utmMedium: "social",
     utmCampaign: "brand_profile",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "seo:inventory": "npx ts-node scripts/seo-inventory.ts",
     "seo:lint": "npx ts-node scripts/seo-lint.ts",
     "canonical:check": "npx ts-node scripts/verify-canonical.ts",
-    "validate:blog-links": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/validate-blog-links.ts"
+    "validate:blog-links": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/validate-blog-links.ts",
+    "qa:campaign-links": "node scripts/qa-campaign-links.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.0.0",

--- a/scripts/qa-campaign-links.mjs
+++ b/scripts/qa-campaign-links.mjs
@@ -1,0 +1,72 @@
+import fs from "node:fs"
+import path from "node:path"
+
+const BASE_URL = process.env.BASE_URL || "https://prism-website-gamma.vercel.app"
+const sourcePath = path.resolve("lib/campaign-links.ts")
+const source = fs.readFileSync(sourcePath, "utf8")
+
+function parseLinks(ts) {
+  const links = []
+  const entryRegex = /"([a-z0-9-]+)"\s*:\s*\{([\s\S]*?)\n\s*\},/g
+  for (const match of ts.matchAll(entryRegex)) {
+    const slugKey = match[1]
+    const body = match[2]
+    const get = (name) => {
+      const m = body.match(new RegExp(`${name}:\\s*\"([^\"]+)\"`))
+      return m?.[1]
+    }
+
+    const enabled = !/enabled:\s*false/.test(body)
+    if (!enabled) continue
+
+    links.push({
+      slug: slugKey,
+      utmSource: get("utmSource"),
+      utmMedium: get("utmMedium"),
+      utmCampaign: get("utmCampaign"),
+      utmContent: get("utmContent"),
+      utmTerm: get("utmTerm"),
+    })
+  }
+  return links
+}
+
+async function check(link) {
+  const response = await fetch(`${BASE_URL}/go/${link.slug}`, { redirect: "manual" })
+  const location = response.headers.get("location") || ""
+
+  if (response.status < 300 || response.status >= 400) {
+    return { slug: link.slug, ok: false, reason: `Expected 3xx, got ${response.status}` }
+  }
+
+  const u = new URL(location)
+  const required = [
+    ["utm_source", link.utmSource],
+    ["utm_medium", link.utmMedium],
+    ["utm_campaign", link.utmCampaign],
+  ]
+
+  for (const [k, v] of required) {
+    if (!v || u.searchParams.get(k) !== v) {
+      return { slug: link.slug, ok: false, reason: `Mismatch ${k}` }
+    }
+  }
+
+  if (link.utmContent && u.searchParams.get("utm_content") !== link.utmContent) {
+    return { slug: link.slug, ok: false, reason: "Mismatch utm_content" }
+  }
+  if (link.utmTerm && u.searchParams.get("utm_term") !== link.utmTerm) {
+    return { slug: link.slug, ok: false, reason: "Mismatch utm_term" }
+  }
+
+  return { slug: link.slug, ok: true }
+}
+
+const links = parseLinks(source)
+const results = await Promise.all(links.map(check))
+const failed = results.filter((r) => !r.ok)
+
+console.log(`Checked ${results.length} campaign slugs against ${BASE_URL}`)
+for (const r of results) console.log(`${r.ok ? "✅" : "❌"} ${r.slug}${r.reason ? ` - ${r.reason}` : ""}`)
+
+if (failed.length) process.exit(1)

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -15,6 +15,112 @@ declare global {
   }
 }
 
+type AttributionPayload = {
+  utm_source?: string
+  utm_medium?: string
+  utm_campaign?: string
+  utm_content?: string
+  utm_term?: string
+  gclid?: string
+  fbclid?: string
+  msclkid?: string
+  landing_path?: string
+  first_touch_source?: string
+  first_touch_medium?: string
+  first_touch_campaign?: string
+  first_touch_at?: string
+}
+
+const ATTRIBUTION_STORAGE_KEY = "prism_attribution_v1"
+const ATTRIBUTION_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+function parseAttributionFromUrl(): AttributionPayload {
+  if (typeof window === "undefined") return {}
+
+  const params = new URLSearchParams(window.location.search)
+  const payload: AttributionPayload = {
+    utm_source: params.get("utm_source") ?? undefined,
+    utm_medium: params.get("utm_medium") ?? undefined,
+    utm_campaign: params.get("utm_campaign") ?? undefined,
+    utm_content: params.get("utm_content") ?? undefined,
+    utm_term: params.get("utm_term") ?? undefined,
+    gclid: params.get("gclid") ?? undefined,
+    fbclid: params.get("fbclid") ?? undefined,
+    msclkid: params.get("msclkid") ?? undefined,
+  }
+
+  return payload
+}
+
+function readStoredAttribution(): (AttributionPayload & { savedAt?: number }) | null {
+  if (typeof window === "undefined") return null
+
+  try {
+    const raw = window.localStorage.getItem(ATTRIBUTION_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as AttributionPayload & { savedAt?: number }
+    if (!parsed.savedAt || Date.now() - parsed.savedAt > ATTRIBUTION_TTL_MS) {
+      window.localStorage.removeItem(ATTRIBUTION_STORAGE_KEY)
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function writeStoredAttribution(payload: AttributionPayload) {
+  if (typeof window === "undefined") return
+
+  try {
+    const existing = readStoredAttribution() ?? {}
+    const merged: AttributionPayload & { savedAt: number } = {
+      ...existing,
+      ...payload,
+      landing_path: existing.landing_path ?? window.location.pathname,
+      first_touch_source: existing.first_touch_source ?? payload.utm_source,
+      first_touch_medium: existing.first_touch_medium ?? payload.utm_medium,
+      first_touch_campaign: existing.first_touch_campaign ?? payload.utm_campaign,
+      first_touch_at: existing.first_touch_at ?? new Date().toISOString(),
+      savedAt: Date.now(),
+    }
+    window.localStorage.setItem(ATTRIBUTION_STORAGE_KEY, JSON.stringify(merged))
+  } catch {
+    // no-op
+  }
+}
+
+function getAttributionContext(): AttributionPayload {
+  if (typeof window === "undefined") return {}
+
+  const fromUrl = parseAttributionFromUrl()
+  const hasCampaignParams = Boolean(
+    fromUrl.utm_source || fromUrl.utm_medium || fromUrl.utm_campaign || fromUrl.gclid || fromUrl.fbclid || fromUrl.msclkid,
+  )
+
+  if (hasCampaignParams) {
+    writeStoredAttribution(fromUrl)
+  }
+
+  const stored = readStoredAttribution() ?? {}
+
+  return {
+    utm_source: fromUrl.utm_source ?? stored.utm_source,
+    utm_medium: fromUrl.utm_medium ?? stored.utm_medium,
+    utm_campaign: fromUrl.utm_campaign ?? stored.utm_campaign,
+    utm_content: fromUrl.utm_content ?? stored.utm_content,
+    utm_term: fromUrl.utm_term ?? stored.utm_term,
+    gclid: fromUrl.gclid ?? stored.gclid,
+    fbclid: fromUrl.fbclid ?? stored.fbclid,
+    msclkid: fromUrl.msclkid ?? stored.msclkid,
+    landing_path: stored.landing_path,
+    first_touch_source: stored.first_touch_source,
+    first_touch_medium: stored.first_touch_medium,
+    first_touch_campaign: stored.first_touch_campaign,
+    first_touch_at: stored.first_touch_at,
+  }
+}
+
 // Custom event types
 export type EventType =
   | "page_view"
@@ -50,8 +156,9 @@ export function trackEvent(eventName: EventType, params?: Record<string, any>) {
   const pageLocation = window.location.href
   const pageTitle = typeof document !== "undefined" ? document.title : ""
 
-  // Add timestamp to all events
+  // Add timestamp and attribution context to all events
   const enhancedParams = {
+    ...getAttributionContext(),
     ...params,
     event_time: new Date().toISOString(),
     page_location: pageLocation,


### PR DESCRIPTION
## What this ships
- Adds clean shortlink route: `/go/:slug` via `app/go/[slug]/route.ts`
- Adds campaign link registry in `lib/campaign-links.ts`
- Injects canonical UTM params server-side during redirect
- Preserves non-UTM query params through redirect
- Adds attribution persistence/enrichment in `utils/analytics.ts` (30-day first-party storage)
- Adds docs: `docs/utm-shortlinks.md`

## Why
- Keep public links clean while maintaining campaign attribution
- Reduce unattributed/direct leakage by carrying first-touch campaign context into downstream events

## Validation
- `pnpm typecheck`
- `pnpm lint`

## Notes
- Unknown slugs redirect to `/get-started` with `utm_campaign=unknown_slug` for visibility.
- Registry currently includes starter slugs (`ig-bio`, `x-profile`, `yt-description`, `newsletter`, `partner-referral`).
