### PR TITLE
Balance homepage proven-results card layout on tablet/desktop

### DIFF
--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -329,7 +329,7 @@ export default function ClientPage() {
                 We&apos;ve implemented this same strategy for 20+ businesses — here are recent examples.
               </p>
             </div>
-            <div className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <div className="mt-10 grid gap-4 md:grid-cols-2 lg:grid-cols-6 [&>*]:lg:col-span-2 [&>*:nth-child(4)]:lg:col-start-2 [&>*:nth-child(5)]:lg:col-start-4">
               {HOMEPAGE_CASE_STUDIES.map((study) => (
                 <CaseStudyCard
                   key={study.id}


### PR DESCRIPTION
## What changed
- Updated homepage proven-results card grid in `app/client-page.tsx`
- Switched from `md:grid-cols-2 xl:grid-cols-4` to a 6-column desktop layout
- Each card spans 2 columns on desktop
- Centered the 4th and 5th cards on the second row using nth-child col-start rules

## Why
The section has 5 cards. The prior layout left an awkward single card on large screens. This change keeps mobile behavior intact while balancing tablet/desktop composition.

## Validation
- `pnpm lint` passed
- `pnpm typecheck` currently fails from existing repo state (`.next/types/validator.ts` cannot resolve `app/go/[slug]/route.js`), unrelated to this one-line layout change.
