### PR TITLE
Phase 1 GA hardening: shortlinks + attribution persistence

### DIFF
--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { getCampaignLink } from "@/lib/campaign-links"
+
+export const runtime = "edge"
+
+const RESERVED_PARAMS = new Set([
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+])
+
+function toAbsoluteUrl(input: string, req: NextRequest): URL {
+  if (input.startsWith("http://") || input.startsWith("https://")) {
+    return new URL(input)
+  }
+
+  return new URL(input.startsWith("/") ? input : `/${input}`, req.nextUrl.origin)
+}
+
+export async function GET(req: NextRequest, context: { params: Promise<{ slug: string }> }) {
+  const { slug } = await context.params
+  const link = getCampaignLink(slug)
+
+  if (!link) {
+    const fallback = new URL("/get-started", req.nextUrl.origin)
+    fallback.searchParams.set("utm_source", "shortlink")
+    fallback.searchParams.set("utm_medium", "redirect")
+    fallback.searchParams.set("utm_campaign", "unknown_slug")
+    fallback.searchParams.set("utm_content", slug)
+    return NextResponse.redirect(fallback, { status: 302 })
+  }
+
+  const target = toAbsoluteUrl(link.destination, req)
+
+  target.searchParams.set("utm_source", link.utmSource)
+  target.searchParams.set("utm_medium", link.utmMedium)
+  target.searchParams.set("utm_campaign", link.utmCampaign)
+  if (link.utmContent) target.searchParams.set("utm_content", link.utmContent)
+  if (link.utmTerm) target.searchParams.set("utm_term", link.utmTerm)
+
+  req.nextUrl.searchParams.forEach((value, key) => {
+    if (!RESERVED_PARAMS.has(key)) target.searchParams.set(key, value)
+  })
+
+  return NextResponse.redirect(target, { status: link.permanent ? 301 : 302 })
+}

--- a/lib/campaign-links.ts
+++ b/lib/campaign-links.ts
@@ -1,0 +1,93 @@
+export type CampaignLink = {
+  slug: string
+  destination: string
+  utmSource: string
+  utmMedium: string
+  utmCampaign: string
+  utmContent?: string
+  utmTerm?: string
+  permanent?: boolean
+  enabled?: boolean
+}
+
+export const CAMPAIGN_LINKS: Record<string, CampaignLink> = {
+  "ig-bio": {
+    slug: "ig-bio",
+    destination: "/offers",
+    utmSource: "instagram",
+    utmMedium: "social",
+    utmCampaign: "brand_profile",
+    utmContent: "bio_link",
+    enabled: true,
+  },
+  "x-profile": {
+    slug: "x-profile",
+    destination: "/proof",
+    utmSource: "x",
+    utmMedium: "social",
+    utmCampaign: "brand_profile",
+    utmContent: "profile_link",
+    enabled: true,
+  },
+  "linkedin-profile": {
+    slug: "linkedin-profile",
+    destination: "/proof",
+    utmSource: "linkedin",
+    utmMedium: "social",
+    utmCampaign: "brand_profile",
+    utmContent: "profile_link",
+    enabled: true,
+  },
+  "tiktok-bio": {
+    slug: "tiktok-bio",
+    destination: "/offers",
+    utmSource: "tiktok",
+    utmMedium: "social",
+    utmCampaign: "brand_profile",
+    utmContent: "bio_link",
+    enabled: true,
+  },
+  "yt-description": {
+    slug: "yt-description",
+    destination: "/blog",
+    utmSource: "youtube",
+    utmMedium: "social",
+    utmCampaign: "content_distribution",
+    utmContent: "video_description",
+    enabled: true,
+  },
+  newsletter: {
+    slug: "newsletter",
+    destination: "/blog",
+    utmSource: "email",
+    utmMedium: "email",
+    utmCampaign: "newsletter",
+    utmContent: "weekly_digest",
+    enabled: true,
+  },
+  "email-signature": {
+    slug: "email-signature",
+    destination: "/get-started",
+    utmSource: "email",
+    utmMedium: "email",
+    utmCampaign: "email_signature",
+    utmContent: "founder_signature",
+    enabled: true,
+  },
+  "partner-referral": {
+    slug: "partner-referral",
+    destination: "/get-started",
+    utmSource: "partner",
+    utmMedium: "referral",
+    utmCampaign: "partner_referral",
+    utmContent: "network_intro",
+    enabled: true,
+  },
+}
+
+export function getCampaignLink(slug: string): CampaignLink | null {
+  const normalized = slug.trim().toLowerCase()
+  const entry = CAMPAIGN_LINKS[normalized]
+  if (!entry || entry.enabled === false) return null
+  return entry
+}

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -15,6 +15,104 @@ declare global {
   }
 }
 
+type AttributionPayload = {
+  utm_source?: string
+  utm_medium?: string
+  utm_campaign?: string
+  utm_content?: string
+  utm_term?: string
+  gclid?: string
+  fbclid?: string
+  msclkid?: string
+  landing_path?: string
+  first_touch_source?: string
+  first_touch_medium?: string
+  first_touch_campaign?: string
+  first_touch_at?: string
+}
+
+const ATTRIBUTION_STORAGE_KEY = "prism_attribution_v1"
+const ATTRIBUTION_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+function parseAttributionFromUrl(): AttributionPayload {
+  if (typeof window === "undefined") return {}
+
+  const params = new URLSearchParams(window.location.search)
+  return {
+    utm_source: params.get("utm_source") ?? undefined,
+    utm_medium: params.get("utm_medium") ?? undefined,
+    utm_campaign: params.get("utm_campaign") ?? undefined,
+    utm_content: params.get("utm_content") ?? undefined,
+    utm_term: params.get("utm_term") ?? undefined,
+    gclid: params.get("gclid") ?? undefined,
+    fbclid: params.get("fbclid") ?? undefined,
+    msclkid: params.get("msclkid") ?? undefined,
+  }
+}
+
+function readStoredAttribution(): (AttributionPayload & { savedAt?: number }) | null {
+  if (typeof window === "undefined") return null
+  try {
+    const raw = window.localStorage.getItem(ATTRIBUTION_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as AttributionPayload & { savedAt?: number }
+    if (!parsed.savedAt || Date.now() - parsed.savedAt > ATTRIBUTION_TTL_MS) {
+      window.localStorage.removeItem(ATTRIBUTION_STORAGE_KEY)
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function writeStoredAttribution(payload: AttributionPayload) {
+  if (typeof window === "undefined") return
+  try {
+    const existing = readStoredAttribution() ?? {}
+    const merged: AttributionPayload & { savedAt: number } = {
+      ...existing,
+      ...payload,
+      landing_path: existing.landing_path ?? window.location.pathname,
+      first_touch_source: existing.first_touch_source ?? payload.utm_source,
+      first_touch_medium: existing.first_touch_medium ?? payload.utm_medium,
+      first_touch_campaign: existing.first_touch_campaign ?? payload.utm_campaign,
+      first_touch_at: existing.first_touch_at ?? new Date().toISOString(),
+      savedAt: Date.now(),
+    }
+    window.localStorage.setItem(ATTRIBUTION_STORAGE_KEY, JSON.stringify(merged))
+  } catch {
+    // no-op
+  }
+}
+
+function getAttributionContext(): AttributionPayload {
+  if (typeof window === "undefined") return {}
+
+  const fromUrl = parseAttributionFromUrl()
+  const hasCampaignParams = Boolean(
+    fromUrl.utm_source || fromUrl.utm_medium || fromUrl.utm_campaign || fromUrl.gclid || fromUrl.fbclid || fromUrl.msclkid,
+  )
+  if (hasCampaignParams) writeStoredAttribution(fromUrl)
+
+  const stored = readStoredAttribution() ?? {}
+  return {
+    utm_source: fromUrl.utm_source ?? stored.utm_source,
+    utm_medium: fromUrl.utm_medium ?? stored.utm_medium,
+    utm_campaign: fromUrl.utm_campaign ?? stored.utm_campaign,
+    utm_content: fromUrl.utm_content ?? stored.utm_content,
+    utm_term: fromUrl.utm_term ?? stored.utm_term,
+    gclid: fromUrl.gclid ?? stored.gclid,
+    fbclid: fromUrl.fbclid ?? stored.fbclid,
+    msclkid: fromUrl.msclkid ?? stored.msclkid,
+    landing_path: stored.landing_path,
+    first_touch_source: stored.first_touch_source,
+    first_touch_medium: stored.first_touch_medium,
+    first_touch_campaign: stored.first_touch_campaign,
+    first_touch_at: stored.first_touch_at,
+  }
+}
+
 // Custom event types
 export type EventType =
   | "page_view"
@@ -50,8 +148,9 @@ export function trackEvent(eventName: EventType, params?: Record<string, any>) {
   const pageLocation = window.location.href
   const pageTitle = typeof document !== "undefined" ? document.title : ""
 
-  // Add timestamp to all events
+  // Add timestamp and attribution context to all events
   const enhancedParams = {
+    ...getAttributionContext(),
     ...params,
     event_time: new Date().toISOString(),
     page_location: pageLocation,


### PR DESCRIPTION
## What this ships
- Adds clean shortlink route `/go/:slug` with server-side UTM injection
- Adds campaign link registry (`lib/campaign-links.ts`)
- Preserves non-UTM query params during redirect
- Adds 30-day attribution persistence in client analytics (`utils/analytics.ts`)
- Enriches events with current/stored attribution fields + first-touch fields

## Why
Improve GA attribution quality and reduce misclassified direct traffic before GA4 dashboard/admin changes.

## Validation
- pnpm lint
- pnpm typecheck
