### PR TITLE
Fix /go redirect query passthrough for slug param

### DIFF
--- a/app/go/[slug]/route.ts
+++ b/app/go/[slug]/route.ts
@@ -10,6 +10,7 @@ const RESERVED_PARAMS = new Set([
   "utm_campaign",
   "utm_content",
   "utm_term",
+  "slug",
 ])
 
 function toAbsoluteUrl(input: string, req: NextRequest): URL {


### PR DESCRIPTION
Prevents internal dynamic route param (slug) from being appended to destination query strings for `/go/:slug` redirects.
