### PR TITLE
Blog skip-link + decorative-numeral a11y; prioritize first blog image

### DIFF
--- a/app/blog/BlogPage.tsx
+++ b/app/blog/BlogPage.tsx
@@ -38,7 +38,7 @@ export default function BlogPage({ posts }: { posts: BlogPost[] }) {
   return (
     <div className="flex min-h-screen flex-col">
       <Navbar />
-      <main className="flex-1 relative">
+      <main className="flex-1 relative" id="main-content" tabIndex={-1}>
         <div className="container mx-auto px-4 md:px-6">
           <Breadcrumbs items={[{ name: "Home", url: "/" }, { name: "Blog", url: "/blog" }]} />
         </div>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -66,7 +66,7 @@ export default async function Blog({
   return (
     <div className="blog-reading-surface flex min-h-screen flex-col">
       <Navbar />
-      <main className="relative flex-1">
+      <main className="relative flex-1" id="main-content" tabIndex={-1}>
         <div className="container mx-auto px-4 md:px-6">
           <Breadcrumbs items={[{ name: "home", url: "/" }, { name: "blog", url: "/blog" }]} />
         </div>
@@ -93,7 +93,7 @@ export default async function Blog({
           <div className="container mx-auto px-4 md:px-6">
             {filteredPosts.length > 0 ? (
               <SimpleBlogGrid>
-                {filteredPosts.map((post) => (
+                {filteredPosts.map((post, index) => (
                     <SimpleBlogPostCard
                       key={post.slug}
                       title={post.title}
@@ -105,6 +105,7 @@ export default async function Blog({
                       image={post.image}
                       gradientClass={post.gradientClass}
                       prefetch={false}
+                      priority={index === 0}
                   />
                 ))}
               </SimpleBlogGrid>

--- a/components/blog-post-layout.tsx
+++ b/components/blog-post-layout.tsx
@@ -135,7 +135,7 @@ export default function BlogPostLayout({
       <BlogScrollProgress />
 
       <Navbar />
-      <main className="flex-1">
+      <main className="flex-1" id="main-content" tabIndex={-1}>
         <div className="w-full py-6 sm:py-8 md:py-10">
           <div className="container mx-auto px-4 sm:px-6">
             <div className={cn('mx-auto', hasToc ? 'max-w-6xl' : 'max-w-3xl')}>

--- a/components/home/HomeDentistWinsCarousel.tsx
+++ b/components/home/HomeDentistWinsCarousel.tsx
@@ -280,7 +280,10 @@ export default function HomeDentistWinsCarousel({
                         ) : (
                           <span />
                         )}
-                        <span className="font-mono text-[10px] font-semibold tracking-[0.22em] text-[#f5f0e8]/65">
+                        <span
+                          aria-hidden="true"
+                          className="font-mono text-[10px] font-semibold tracking-[0.22em] text-[#f5f0e8]/65"
+                        >
                           {String(index + 1).padStart(2, '0')}
                         </span>
                       </div>

--- a/components/home/HomeEcosystemSection.tsx
+++ b/components/home/HomeEcosystemSection.tsx
@@ -37,7 +37,10 @@ export default function HomeEcosystemSection() {
                 key={step.title}
                 className="border-t border-white/12 pt-5 first:pt-0 first:border-t-0"
               >
-                <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.32em] text-[#8f877b]">
+                <p
+                  aria-hidden="true"
+                  className="font-mono text-[11px] font-semibold uppercase tracking-[0.32em] text-[#8f877b]"
+                >
                   0{index + 1}
                 </p>
                 <h3 className="mt-4 max-w-[18ch] font-sans text-[1.65rem] font-medium leading-[1.02] tracking-[-0.05em] text-[#f5f0e8]">

--- a/components/home/HomeHowItWorksSection.tsx
+++ b/components/home/HomeHowItWorksSection.tsx
@@ -60,7 +60,7 @@ export default function HomeHowItWorksSection() {
                   <div className={styles.track}>
                     <span className={styles.node}>
                       <Icon aria-hidden="true" size={24} strokeWidth={1.6} />
-                      <span className={styles.badge}>
+                      <span className={styles.badge} aria-hidden="true">
                         {String(index + 1).padStart(2, '0')}
                       </span>
                     </span>

--- a/components/simple-blog-post-card.tsx
+++ b/components/simple-blog-post-card.tsx
@@ -16,6 +16,8 @@ interface SimpleBlogPostCardProps {
   compact?: boolean
   gradientClass: string
   prefetch?: boolean
+  /** Eager-load + fetchpriority high for the first card (the /blog LCP image). */
+  priority?: boolean
 }
 
 export default function SimpleBlogPostCard({
@@ -30,6 +32,7 @@ export default function SimpleBlogPostCard({
   compact = false,
   gradientClass,
   prefetch,
+  priority = false,
 }: SimpleBlogPostCardProps) {
   const featuredImage =
     typeof image === 'string' && image.trim().length > 0
@@ -57,7 +60,8 @@ export default function SimpleBlogPostCard({
             src={featuredImage}
             alt={`${title} featured image`}
             fill
-            loading="lazy"
+            priority={priority}
+            loading={priority ? undefined : 'lazy'}
             sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
             className="object-cover"
           />


### PR DESCRIPTION
Follow-up batch after the LCP canvas fix. All local gates green: typecheck, lint, 266 Jest tests, production build.

## Accessibility (axe audit follow-ups)
- **Blog skip-link target (WCAG 2.4.1):** added static `id="main-content" tabIndex={-1}` to the blog `<main>` elements so "Skip to content" resolves on blog routes (it previously only got the id via a post-hydration effect). The skip-to-content helper only sets the id when absent, so there's exactly one target — no duplicate id.
- **Decorative numerals:** `aria-hidden` on the purely decorative low-contrast ordinal markers on the homepage (ecosystem steps, how-it-works badge, carousel counter). Meaningful numerals (phases, stats) left untouched.

## Performance
- After the ASCII→canvas fix, the `/blog` LCP is the first post-card image (measured ~4.1s on prod). Marked the first card's image `priority` (eager + fetchpriority high + preload); the rest stay lazy.

## Context (measurement)
Re-measured prod after the canvas fix: `/` LCP **4.9s → ~2.7-3.0s**, `/blog` **6.8s → ~4.1s** — the ASCII is no longer the LCP element. The remaining ~2.7s text floor is a single ~539KB render-blocking Tailwind stylesheet. I tested `experimental.inlineCss` for it but it inlined the whole monolith into every page (~1.4MB HTML, lost CSS caching), so it was reverted — the real fix is shrinking globals.css (dedicated follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)