### PR TITLE
Improve mobile UX across the get-started / contact funnels

### DIFF
--- a/app/founder-os/page.tsx
+++ b/app/founder-os/page.tsx
@@ -762,7 +762,7 @@ function PremiumSection({
   return (
     <section
       id={id}
-      className={`relative scroll-mt-20 overflow-hidden border-b border-[#ededed] px-5 py-20 sm:px-8 sm:py-28 ${toneClassName} ${className}`}
+      className={`relative scroll-mt-28 overflow-hidden border-b border-[#ededed] px-5 py-20 sm:px-8 sm:py-28 ${toneClassName} ${className}`}
     >
       {tone !== 'dark' ? (
         <div

--- a/components/forms/FounderOsApplicationForm.tsx
+++ b/components/forms/FounderOsApplicationForm.tsx
@@ -779,7 +779,7 @@ export default function FounderOsApplicationForm() {
 
   const focusFirstInvalid = () => {
     if (typeof window === 'undefined') return
-    if (window.matchMedia?.('(max-width: 767px)').matches) return
+    const isMobile = window.matchMedia?.('(max-width: 767px)').matches ?? false
 
     window.requestAnimationFrame(() => {
       const form = formRef.current
@@ -794,7 +794,15 @@ export default function FounderOsApplicationForm() {
               'input, textarea, select, button, [tabindex]',
             ))
       const target = focusable || errorRef.current
+      // Focus without scrolling so the on-screen keyboard doesn't yank the
+      // viewport, then explicitly bring the field (or error banner) into view.
       target?.focus({ preventScroll: true })
+      if (isMobile) {
+        // On mobile the inline/banner error can render far above the viewport,
+        // so smooth-scroll it into view; otherwise the page looks unresponsive.
+        const scrollTarget = focusable || errorRef.current
+        scrollTarget?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+      }
     })
   }
 
@@ -2016,7 +2024,7 @@ export default function FounderOsApplicationForm() {
               {[
                 ['Prism Growth Dashboard', 'Start with the free Growth Dashboard and systems work.', '/get-started'],
                 ['A systems foundation', 'Tracking, CRM cleanup, and data consolidation first.', '/services'],
-                ['Founder OS waitlist', 'We&apos;ll reach out when the timing fits.', '/contact?topic=founder-os-waitlist'],
+                ['Founder OS waitlist', 'We’ll reach out when the timing fits.', '/contact?topic=founder-os-waitlist'],
               ].map(([title, body, href]) => (
                 <a
                   key={title}

--- a/components/forms/GetStartedForm.tsx
+++ b/components/forms/GetStartedForm.tsx
@@ -174,10 +174,23 @@ function normalizeReviewLink(value: string) {
   return `https://${trimmed}`
 }
 
-function isValidReviewLink(value: string) {
+function isValidReviewLink(value: string, requireDomain = false) {
+  if (/\s/.test(value)) return false
+
   try {
     const parsed = new URL(value)
-    return Boolean(parsed.hostname)
+    if (!parsed.hostname) return false
+
+    if (requireDomain) {
+      // Website-URL path: demand a real domain (a dot + a 2+ letter TLD).
+      // This rejects bare words like "not a url" or "localhost" that
+      // otherwise pass once `https://` is prepended.
+      return /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/.test(
+        parsed.hostname,
+      )
+    }
+
+    return true
   } catch {
     return false
   }
@@ -634,7 +647,10 @@ export default function GetStartedForm() {
             field.value = normalized
           }
 
-          if (!isValidReviewLink(field.value)) {
+          // Only the website-URL path requires a real domain; the
+          // profile/handle path stays intentionally permissive.
+          const requireDomain = hasWebsite === 'yes'
+          if (!isValidReviewLink(field.value, requireDomain)) {
             message = 'Add a valid link'
           }
         }
@@ -659,7 +675,7 @@ export default function GetStartedForm() {
       field.setCustomValidity(message)
       commitTextField(field)
     },
-    [commitTextField],
+    [commitTextField, hasWebsite],
   )
 
   const getNamedFields = useCallback((names: readonly string[]) => {
@@ -700,6 +716,28 @@ export default function GetStartedForm() {
       )
 
       field?.focus({ preventScroll: true })
+    },
+    [getNamedFields],
+  )
+
+  const scrollFieldIntoView = useCallback(
+    (name: string) => {
+      // Bring the first invalid control (or its error message) into view even
+      // on mobile, where auto-focus is skipped and the sticky footer can
+      // otherwise occlude inline errors.
+      const form = formRef.current
+      if (!form) return
+
+      const target =
+        form.querySelector<HTMLElement>(`#${name}-error`) ||
+        (name === 'service_focus'
+          ? form.querySelector<HTMLElement>('[data-service-option="true"]')
+          : getNamedFields([name]).find(
+              (candidate) =>
+                candidate.type !== 'hidden' && candidate.tabIndex !== -1,
+            ) || null)
+
+      target?.scrollIntoView?.({ block: 'center', behavior: 'smooth' })
     },
     [getNamedFields],
   )
@@ -832,7 +870,10 @@ export default function GetStartedForm() {
         service_count: selectedServices.length,
         question_count: QUESTION_STEP_COUNT,
       })
-      queueMicrotask(() => focusNamedField('service_focus'))
+      queueMicrotask(() => {
+        focusNamedField('service_focus')
+        scrollFieldIntoView('service_focus')
+      })
       return
     }
 
@@ -920,7 +961,10 @@ export default function GetStartedForm() {
         service_count: selectedServices.length,
         question_count: QUESTION_STEP_COUNT,
       })
-      queueMicrotask(() => focusNamedField(manualError.name))
+      queueMicrotask(() => {
+        focusNamedField(manualError.name)
+        scrollFieldIntoView(manualError.name)
+      })
       return
     }
 
@@ -941,11 +985,12 @@ export default function GetStartedForm() {
         service_count: selectedServices.length,
         question_count: QUESTION_STEP_COUNT,
       })
-      queueMicrotask(() =>
-        focusNamedField(
-          invalidField?.name || getStepFields(currentStep)[0] || 'unknown',
-        ),
-      )
+      queueMicrotask(() => {
+        const invalidName =
+          invalidField?.name || getStepFields(currentStep)[0] || 'unknown'
+        focusNamedField(invalidName)
+        scrollFieldIntoView(invalidName)
+      })
       return
     }
 
@@ -1528,7 +1573,7 @@ export default function GetStartedForm() {
           </div>
         </div>
 
-        <div className="flex flex-1 flex-col justify-center py-12 sm:py-16">
+        <div className="flex flex-1 flex-col justify-center py-12 pb-24 sm:py-16 sm:pb-16">
           <div className="space-y-7">
             <div className="space-y-3">
               <h1 className="max-w-[12ch] text-balance font-sans text-[clamp(2.25rem,8vw,4.8rem)] font-medium leading-[0.95] tracking-[-0.06em] text-[#F5F5F2]">
@@ -1554,7 +1599,7 @@ export default function GetStartedForm() {
               <Button
                 type="button"
                 variant="outline"
-                className="min-h-12 border-white/14 bg-transparent px-5 font-mono text-[0.78rem] uppercase tracking-[0.18em] text-[#D0D0C8] hover:border-white/28 hover:bg-white/5 hover:text-[#F5F5F2]"
+                className="min-h-12 shrink-0 border-white/14 bg-transparent px-5 font-mono text-[0.78rem] uppercase tracking-[0.18em] text-[#D0D0C8] hover:border-white/28 hover:bg-white/5 hover:text-[#F5F5F2]"
                 onClick={handleBack}
               >
                 Back
@@ -1564,8 +1609,8 @@ export default function GetStartedForm() {
             {currentStep === 'fit' ? (
               <Button
                 type="button"
-                variant="outline"
-                className="min-h-12 border-white/14 bg-transparent px-5 font-mono text-[0.78rem] uppercase tracking-[0.18em] text-[#A8A8A1] hover:border-white/28 hover:bg-white/5 hover:text-[#F5F5F2]"
+                variant="ghost"
+                className="min-h-12 shrink-0 border-0 bg-transparent px-2 font-mono text-[0.7rem] uppercase tracking-[0.16em] text-[#767670] shadow-none underline-offset-4 hover:bg-transparent hover:text-[#A8A8A1] hover:underline"
                 onClick={handleSkipFit}
               >
                 Skip for now

--- a/components/forms/WebsiteBuildEstimatorForm.tsx
+++ b/components/forms/WebsiteBuildEstimatorForm.tsx
@@ -196,9 +196,12 @@ function normalizeUrl(value: string) {
 }
 
 function isValidUrl(value: string) {
+  if (/\s/.test(value)) return false
   try {
     const parsed = new URL(value)
-    return Boolean(parsed.hostname)
+    // Require a dotted hostname with a 2+ letter TLD so bare words
+    // ("not a url", "foo", "foo.") are rejected after normalization.
+    return /^(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(parsed.hostname)
   } catch {
     return false
   }
@@ -857,6 +860,7 @@ export default function WebsiteBuildEstimatorForm() {
                   id="website-build-email"
                   name="email"
                   type="email"
+                  inputMode="email"
                   required
                   autoComplete="email"
                   spellCheck={false}
@@ -1024,7 +1028,7 @@ export default function WebsiteBuildEstimatorForm() {
           {/* Mobile-only live estimate: the sidebar is pushed below the fold on
               small screens, so we pin a compact running total to the top of the
               viewport while the user scrolls and edits the current step. */}
-          <div className="sticky top-2 z-30 mt-5 flex items-center justify-between gap-4 border border-[#d8bc79]/30 bg-[#0d0d0d]/95 px-4 py-3 shadow-[0_12px_30px_-18px_rgba(0,0,0,0.9)] backdrop-blur supports-[backdrop-filter]:bg-[#0d0d0d]/80 lg:hidden">
+          <div className="sticky top-[80px] z-30 mt-5 flex items-center justify-between gap-4 border border-[#d8bc79]/30 bg-[#0d0d0d]/95 px-4 py-3 shadow-[0_12px_30px_-18px_rgba(0,0,0,0.9)] backdrop-blur supports-[backdrop-filter]:bg-[#0d0d0d]/80 lg:hidden">
             <span className="font-mono text-[0.68rem] uppercase tracking-[0.2em] text-[#8f877b]">
               Estimated range
             </span>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -261,7 +261,7 @@ export default function Navbar() {
       {isMobileMenuOpen ? (
         <div
           id={MOBILE_NAV_ID}
-          className="max-h-[calc(100dvh-72px)] overflow-y-auto overscroll-contain border-t border-white/12 bg-black lg:hidden"
+          className="h-[calc(100dvh-72px)] overflow-y-auto overscroll-contain border-t border-white/12 bg-black lg:hidden"
         >
           <nav aria-label="Main" className="container mx-auto px-4 sm:px-6">
             <div className="divide-y divide-white/12">

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -49,4 +49,5 @@ export const NAV_ITEMS: NavItem[] = [
   { label: "results", href: "/case-studies" },
   { label: "wall of love", href: "/wall-of-love" },
   { label: "free audit", href: "/get-started" },
+  { label: "contact", href: "/contact" },
 ]


### PR DESCRIPTION
Findings from a live mobile audit (iPhone 390px) of all key funnels — get-started/apply, website estimator, Founder OS, and contact. All local gates green: typecheck, lint, 266 Jest tests, production build. Key fixes verified visually on a local production build.

## Fixes
- **Mobile validation now visible.** Errors were hidden behind the sticky footer (/apply step 1) or rendered off-screen above the viewport (Founder OS apply — `focusFirstInvalid` early-returned on mobile). Both now scroll the first invalid field/error into view; /apply also gets bottom padding so the last option + error clear the sticky bar. (Users were tapping "Continue" and seeing nothing happen.)
- **Estimator running-total badge** no longer tucks under the 72px navbar while scrolling (`top-2` → `top-[80px]`).
- **Mobile nav:** added **Contact** (the get-in-contact path was missing) and made the open menu a **full-height overlay** (homepage no longer bleeds through).
- **Founder OS:** fixed a literal `We&apos;ll` HTML entity in the offramp; bumped section `scroll-mt` so headings clear the sticky header.
- **URL validation hardened** in apply + estimator (reject dotless/whitespace inputs so junk links aren't emailed).
- **Polish:** fit-step primary Continue button emphasis; `inputMode="email"`.

## Deliberately not done
Did **not** add a booking link to `/contact` — a test enforces that the demo/booking path stays off that page (respected that decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)