### PR TITLE
Booking discoverability (footer) + contact-form phone field

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import TrackedLink from '@/components/tracked-link'
+import { BOOKING_URL } from '@/lib/booking'
 
 type FooterItem = {
   href: string
@@ -102,6 +103,16 @@ export default function Footer({ variant: _variant = 'default' }: FooterProps) {
               >
                 Free audit
               </TrackedLink>
+              <a
+                href={BOOKING_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-cta-text="book a call"
+                data-cta-location="footer"
+                className="inline-flex min-h-12 items-center border-b border-[#8f877b] pb-1 text-sm font-semibold uppercase tracking-[0.18em] text-[#b8afa2] transition-colors hover:border-[#f5f0e8] hover:text-[#f5f0e8] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-[#5cdcff]/40 focus-visible:ring-offset-4 focus-visible:ring-offset-black"
+              >
+                Book a call
+              </a>
             </div>
           </div>
 

--- a/components/forms/ContactForm.tsx
+++ b/components/forms/ContactForm.tsx
@@ -96,6 +96,7 @@ export default function ContactForm() {
           name="name"
           placeholder="Jordan Ramirez"
           autoComplete="name"
+          className="min-h-11"
           aria-invalid={Boolean(getError('name'))}
           aria-describedby={describedBy('name')}
           onBlur={handleBlur}
@@ -110,15 +111,35 @@ export default function ContactForm() {
           id="contact-email"
           name="email"
           type="email"
+          inputMode="email"
           required
           placeholder="you@company.com"
           autoComplete="email"
+          className="min-h-11"
           aria-invalid={Boolean(getError('email'))}
           aria-describedby={describedBy('email')}
           onBlur={handleBlur}
           onInput={handleInput}
         />
         {renderError('email')}
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="contact-phone">Phone (optional)</Label>
+        <Input
+          id="contact-phone"
+          name="phone"
+          type="tel"
+          inputMode="tel"
+          placeholder="(555) 123-4567"
+          autoComplete="tel"
+          className="min-h-11"
+          aria-invalid={Boolean(getError('phone'))}
+          aria-describedby={describedBy('phone')}
+          onBlur={handleBlur}
+          onInput={handleInput}
+        />
+        {renderError('phone')}
       </div>
 
       <div className="grid gap-2">


### PR DESCRIPTION
Follow-up to the mobile-funnel UX audit, targeting the get-in-contact goal. All local gates green (typecheck, lint, 266 tests, build); verified visually on a local prod build.

- **Footer "Book a call"** next to "Free audit" → the scheduler, so a call is bookable from any page (it was only on /founder-os; the mobile audit rated booking discoverability 3/10). Kept off `/contact` itself, where a test enforces no booking path.
- **Contact form:** optional **Phone** field (`type=tel`/`inputMode=tel`), `inputMode=email` on the email field, and 44px tap-target inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)