### PR TITLE
Load GA4 + Vercel Analytics promptly (reliable capture on /ig /tiktok /youtube)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -91,14 +91,20 @@ export default function RootLayout({
         {IS_ANALYTICS_ENABLED && (
           <>
             {/* Google tag (gtag.js) */}
+            {/* afterInteractive (not lazyOnload): gtag.js must load promptly so
+              queued page_view / generate_lead / Google Ads conversion hits in
+              dataLayer actually flush. lazyOnload waits for browser idle after
+              full load, so fast-bouncing visitors and pre-idle conversions were
+              silently dropped. gtag.js is async and non-render-blocking, so the
+              LCP cost is negligible while data capture becomes reliable. */}
             <Script
               id="ga-loader"
-              strategy="lazyOnload"
+              strategy="afterInteractive"
               src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
             />
             <Script
               id="ga-config"
-              strategy="lazyOnload"
+              strategy="afterInteractive"
               dangerouslySetInnerHTML={{
                 __html: `
                   window.dataLayer = window.dataLayer || [];

--- a/components/runtime-client-shell.tsx
+++ b/components/runtime-client-shell.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 
 import AnalyticsProvider from '@/components/analytics-provider'
 import RouteSurfaceController from '@/components/route-surface-controller'
+import VercelAnalytics from '@/components/vercel-analytics'
 
 type IdleCapableWindow = Window &
   typeof globalThis & {
@@ -65,6 +66,12 @@ export default function RuntimeClientShell() {
     <>
       <RouteSurfaceController />
       <AnalyticsProvider />
+      {/* Vercel Analytics loads with the first-party analytics layer instead of
+        waiting for idle. Its pageview beacon is tiny and non-blocking, and the
+        idle deferral was undercounting fast-bounce traffic on the link-in-bio
+        landing pages (/ig, /tiktok, /youtube), whose mobile in-app-browser
+        visitors often leave before requestIdleCallback ever fires. */}
+      <VercelAnalytics />
       {shouldLoadDeferredFeatures ? <RuntimeDeferredFeatures /> : null}
     </>
   )

--- a/components/runtime-deferred-features.tsx
+++ b/components/runtime-deferred-features.tsx
@@ -13,7 +13,6 @@ import RootClientMonitors from '@/components/root-client-monitors'
 import ScrollTracker from '@/components/scroll-tracker'
 import SentryContextProvider from '@/components/sentry-context-provider'
 import ToasterLazy from '@/components/toaster-lazy'
-import VercelAnalytics from '@/components/vercel-analytics'
 
 export default function RuntimeDeferredFeatures() {
   const pathname = usePathname()
@@ -36,7 +35,6 @@ export default function RuntimeDeferredFeatures() {
         <ErrorTracker />
         <ScrollTracker />
         <Suspense fallback={null}>
-          <VercelAnalytics />
           {shouldMountPublicWidget ? (
             <>
               <ElevenLabsWidgetScript />


### PR DESCRIPTION
Two changes so first-party analytics fires reliably — especially on the link-in-bio landing pages (`/ig`, `/tiktok`, `/youtube`), whose visitors arrive in TikTok/IG/YouTube in-app browsers and often bounce within 1–2s.

## 1. GA4 gtag.js: `lazyOnload` → `afterInteractive` (`app/layout.tsx`)
`lazyOnload` defers gtag.js until the browser goes idle **after** full page load. `page_view` / `generate_lead` / Google Ads `conversion` hits queue in `dataLayer` and only flush once gtag.js runs — so visitors who bounced or converted before idle had those hits **silently dropped**, undercounting GA4 and breaking Google Ads conversion attribution. `afterInteractive` loads it right after hydration (async, non-render-blocking).

## 2. Vercel Analytics: mount promptly instead of idle-deferring (`runtime-client-shell.tsx`, `runtime-deferred-features.tsx`)
`<Analytics/>` was mounted inside `RuntimeDeferredFeatures`, which only hydrates on `requestIdleCallback` (1200ms fallback) via a dynamic `ssr:false` import. Measured on production, the `/_vercel/insights/view` beacon didn't fire until **~1s+** on desktop (later on mobile). Moved it into `RuntimeClientShell` alongside `AnalyticsProvider` so it mounts right after hydration.

## Verified on production (www.design-prism.com)
- All three landing pages **do** currently fire GA4 `page_view` + the Vercel view beacon — but only after the deferral windows above; these changes shrink that window to ~hydration time.
- GA4 ingestion confirmed working (direct `/g/collect` → HTTP 204).
- `pnpm typecheck` + `pnpm lint` pass.

## Still needs GA Admin (not code)
Production fans `G-P9VY77PRC0` out to two connected GA4 properties (`G-54ESSN4BF8`, `G-SNZ80JMX80`); `G-54ESSN4BF8` double-counts page_views (auto + manual). Fix in the GA/Google Tag admin: pick one canonical property, prune stray connected tags, and disable Enhanced Measurement "page changes on history events" (the app sends richer manual page_views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)