### PR TITLE
Homepage perf: smoother scroll + hover (pause off-screen hero, batch pointer/resize)

### DIFF
--- a/components/home/DeferredAsciiHeroBackdrop.tsx
+++ b/components/home/DeferredAsciiHeroBackdrop.tsx
@@ -164,6 +164,18 @@ export default function DeferredAsciiHeroBackdrop(
     )
     const handleChange = () => evaluateProfile()
 
+    // resize fires continuously while dragging a window edge; re-resolving the
+    // profile (and re-rendering) on every event is wasteful, so coalesce bursts
+    // into a single rAF-deferred evaluation.
+    let resizeFrame: number | null = null
+    const handleResize = () => {
+      if (resizeFrame !== null) return
+      resizeFrame = window.requestAnimationFrame(() => {
+        resizeFrame = null
+        evaluateProfile()
+      })
+    }
+
     evaluateProfile()
 
     if (reducedMotionQuery.addEventListener) {
@@ -172,7 +184,7 @@ export default function DeferredAsciiHeroBackdrop(
       reducedMotionQuery.addListener(handleChange)
     }
 
-    window.addEventListener('resize', handleChange)
+    window.addEventListener('resize', handleResize)
 
     return () => {
       if (reducedMotionQuery.removeEventListener) {
@@ -180,7 +192,8 @@ export default function DeferredAsciiHeroBackdrop(
       } else {
         reducedMotionQuery.removeListener(handleChange)
       }
-      window.removeEventListener('resize', handleChange)
+      window.removeEventListener('resize', handleResize)
+      if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame)
     }
   }, [evaluateProfile])
 

--- a/components/home/HomeImpossibleHero.module.css
+++ b/components/home/HomeImpossibleHero.module.css
@@ -23,6 +23,19 @@
  *   3.4s+          idle loops: beam breath, prism halo breath, sheen sweep
  */
 
+/*
+ * Once the 100svh hero scrolls away, skip its rendering entirely. The scene
+ * carries the page's most expensive paint — a full-viewport feTurbulence grain,
+ * several feGaussianBlur filters, and three infinite idle loops — so pausing
+ * that compositing off-screen is the biggest smoothness/battery win on the
+ * page. contain-intrinsic-size reserves the height so scrolling stays jump-free,
+ * and CSS animation timelines resume (not restart) when it re-enters view.
+ */
+.scene {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 100svh;
+}
+
 .beamCore,
 .beamGlow {
   stroke-dasharray: 1;

--- a/components/home/HomeImpossibleHero.tsx
+++ b/components/home/HomeImpossibleHero.tsx
@@ -65,7 +65,10 @@ export default function HomeImpossibleHero() {
     <section
       aria-label="Impossible is temporary"
       data-testid="home-impossible-hero"
-      className="relative flex min-h-[100svh] flex-col items-center justify-center overflow-hidden border-b border-white/12 pb-16 pt-[calc(var(--prism-header-height,4.5rem)+1rem)]"
+      className={cn(
+        'relative flex min-h-[100svh] flex-col items-center justify-center overflow-hidden border-b border-white/12 pb-16 pt-[calc(var(--prism-header-height,4.5rem)+1rem)]',
+        styles.scene,
+      )}
     >
       <div className="flex w-full flex-col items-center">
         <svg

--- a/components/home/HomeSystemGrid.tsx
+++ b/components/home/HomeSystemGrid.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import Link from 'next/link'
-import { useCallback, type PointerEvent as ReactPointerEvent } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
 
 import BrandLogo, {
   type BrandLogoKey,
@@ -37,12 +42,46 @@ const CARD_SPANS = [
 ] as const
 
 export default function HomeSystemGrid({ items }: HomeSystemGridProps) {
+  // The spotlight follows the pointer via CSS custom properties. Writing them
+  // straight from the pointermove handler forces a style recalc per event
+  // (pointermove fires far faster than the display refresh). Coalescing the
+  // read + write into a single rAF keeps hover smooth under rapid movement.
+  const frameRef = useRef<number | null>(null)
+  const pendingRef = useRef<{
+    node: HTMLElement
+    clientX: number
+    clientY: number
+  } | null>(null)
+
   const handlePointerMove = useCallback(
     (event: ReactPointerEvent<HTMLElement>) => {
-      const node = event.currentTarget
-      const rect = node.getBoundingClientRect()
-      node.style.setProperty('--spot-x', `${event.clientX - rect.left}px`)
-      node.style.setProperty('--spot-y', `${event.clientY - rect.top}px`)
+      pendingRef.current = {
+        node: event.currentTarget,
+        clientX: event.clientX,
+        clientY: event.clientY,
+      }
+      if (frameRef.current !== null) return
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null
+        const pending = pendingRef.current
+        if (!pending) return
+        const rect = pending.node.getBoundingClientRect()
+        pending.node.style.setProperty(
+          '--spot-x',
+          `${pending.clientX - rect.left}px`,
+        )
+        pending.node.style.setProperty(
+          '--spot-y',
+          `${pending.clientY - rect.top}px`,
+        )
+      })
+    },
+    [],
+  )
+
+  useEffect(
+    () => () => {
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current)
     },
     [],
   )


### PR DESCRIPTION
Deep-dived the homepage render path. The architecture is already strong — `app/client-page.tsx` is a Server Component composing mostly server sections, with the two weight centers (2.1 MB ASCII backdrop, framer-motion cover-flow deck) both lazily deferred. So these are **surgical smoothness wins**, not a rewrite.

## Changes
**1. Pause the Impossible hero's compositing off-screen** (`HomeImpossibleHero.tsx` + `.module.css`)
The 100svh scene carries the page's most expensive paint: a full-viewport `feTurbulence` grain, several `feGaussianBlur` filters, and **three infinite idle loops** (beam/halo breathe, sheen sweep). These kept compositing even after the hero scrolled away. Added `content-visibility:auto` + `contain-intrinsic-size:auto 100svh` so the browser skips them off-screen — the biggest smoothness/battery win on the page, with no layout jump and no animation restart on re-entry.

**2. rAF-batch the services-grid spotlight** (`HomeSystemGrid.tsx`)
`onPointerMove` did a `getBoundingClientRect()` + two `style.setProperty` **per event** (pointermove fires faster than the refresh rate). Coalesced into one read+write per frame → no style-recalc storm during hover.

**3. rAF-throttle the ASCII backdrop resize** (`DeferredAsciiHeroBackdrop.tsx`)
`resize` re-resolved the profile + re-rendered on every event; now coalesced into one rAF-deferred evaluation.

## Verified
- `pnpm typecheck`, `pnpm lint`, and `pnpm build` all pass.
- Couldn't run a live visual check this session (local browser was closed) — **please eyeball the hero on the Vercel preview** to confirm the entrance animation + grain look unchanged.

## Recommended follow-ups (not in this PR)
- **Shrink the 2.1 MB `public/animations/wave/high/frames.json`** (`frameCount={300}`) — biggest byte reduction; needs regenerating a lower-frame/precompressed asset. It's deferred + pauses off-screen, so it doesn't hurt LCP, but it's a heavy decorative transfer.
- Switch the cover-flow deck to framer-motion `LazyMotion`/`m` to cut the largest lazy chunk.
- Consolidate the ~15 `HomeReveal` IntersectionObservers into one shared observer (or CSS `animation-timeline: view()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)