### PR TITLE
Harden blog search params

### DIFF
--- a/__tests__/search-params.test.ts
+++ b/__tests__/search-params.test.ts
@@ -1,0 +1,18 @@
+import { firstSearchParamString } from "@/lib/search-params"
+
+describe("firstSearchParamString", () => {
+  it("returns string params unchanged", () => {
+    expect(firstSearchParamString("growth")).toBe("growth")
+  })
+
+  it("uses the first string from array params", () => {
+    expect(firstSearchParamString(["seo", "growth"])).toBe("seo")
+  })
+
+  it("falls back for empty, null, and malformed params", () => {
+    expect(firstSearchParamString([], "all")).toBe("all")
+    expect(firstSearchParamString(null, "all")).toBe("all")
+    expect(firstSearchParamString(undefined, "all")).toBe("all")
+    expect(firstSearchParamString([null, "seo"] as unknown as string[], "all")).toBe("seo")
+  })
+})

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/blog-topic-filters"
 import BlogCTAButtonLazy from "./BlogCTAButtonLazy"
 import { buildRouteMetadata } from "@/lib/seo/metadata"
+import { firstSearchParamString, type SearchParamValue } from "@/lib/search-params"
 
 export const metadata: Metadata = buildRouteMetadata({
   titleStem: 'Growth insights',
@@ -29,11 +30,11 @@ export const metadata: Metadata = buildRouteMetadata({
 export default async function Blog({
   searchParams,
 }: {
-  searchParams: Promise<{ category?: string; q?: string }>
+  searchParams: Promise<{ category?: SearchParamValue; q?: SearchParamValue }>
 }) {
   const resolvedSearchParams = await searchParams
-  const rawCategory = resolvedSearchParams?.category ?? "all"
-  const searchQuery = resolvedSearchParams?.q ?? ""
+  const rawCategory = firstSearchParamString(resolvedSearchParams?.category, "all")
+  const searchQuery = firstSearchParamString(resolvedSearchParams?.q)
 
   const posts = await getAllPosts()
   if (!posts) notFound()

--- a/lib/search-params.ts
+++ b/lib/search-params.ts
@@ -1,0 +1,10 @@
+export type SearchParamValue = string | string[] | null | undefined
+
+export function firstSearchParamString(value: SearchParamValue, fallback = "") {
+  if (typeof value === "string") return value
+  if (Array.isArray(value)) {
+    const firstString = value.find((item): item is string => typeof item === "string")
+    return firstString ?? fallback
+  }
+  return fallback
+}


### PR DESCRIPTION
## Summary
- normalize repeated or malformed blog query parameters before filtering
- preserve the existing category fallback
- cover string, array, null, empty, and malformed cases

## Validation
- `pnpm exec jest __tests__/search-params.test.ts --runInBand`
- `pnpm exec eslint app/blog/page.tsx lib/search-params.ts __tests__/search-params.test.ts`
- `pnpm typecheck`
- `pnpm build`

Addresses the server-side `/blog` `f.trim` Sentry path without changing public behavior for valid query parameters.