### PR TITLE
Redesign blog for focused reading

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,11 +1,8 @@
 import BlogPostLayout from '@/components/blog-post-layout'
-import BlogEmailSignup from '@/components/blog-email-signup'
-import { getAllPosts, getPost } from '@/lib/mdx-data'
+import { getPost } from '@/lib/mdx-data'
 import { getBlogOpenGraphImage } from '@/lib/blog-images'
 import { canonicalUrl } from '@/lib/canonical'
 import { renderPost } from '@/lib/mdx'
-import { getMdxToc } from '@/lib/mdx-toc'
-import { getPrismImpactForPost } from '@/lib/prism-blog-impact'
 import { buildAbsoluteTitle, buildMinimalDescription } from '@/lib/seo/rules'
 import {
   getOutboundLinkRulesForPost,
@@ -65,14 +62,6 @@ const estimateReadingMinutes = (content: string) => {
   if (!content) return 1
   const words = stripMarkdown(content).split(/\s+/).filter(Boolean)
   return Math.max(1, Math.ceil(words.length / WORDS_PER_MINUTE))
-}
-
-function deriveTakeawaysFromToc(toc: Array<{ id: string; label: string; level: number }>) {
-  return toc
-    .filter((item) => item.level === 2)
-    .map((item) => item.label.trim())
-    .filter(Boolean)
-    .slice(0, 4)
 }
 
 export async function generateMetadata({
@@ -150,7 +139,6 @@ export default async function BlogPostPage({ params }: PageProps) {
   const post = await getPost(slug)
   if (!post) notFound()
   const { frontmatter } = post
-  const toc = await getMdxToc(post.content)
   const outboundProfile: BlogOutboundLinkProfile =
     getOutboundLinkRulesForPost({
       slug,
@@ -163,22 +151,6 @@ export default async function BlogPostPage({ params }: PageProps) {
   const updatedDate = frontmatter.openGraph?.modifiedTime
   const publishedDate = frontmatter.openGraph?.publishedTime || frontmatter.date
   const content = await renderPost(slug, { content: enrichedContent })
-  const allPosts = (await getAllPosts()) ?? []
-  const relatedPosts = allPosts
-    .filter((p) => p.slug !== slug)
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-  const keyTakeaways = deriveTakeawaysFromToc(toc)
-  const prismImpact = getPrismImpactForPost({
-    slug,
-    category: frontmatter.category,
-    content: post.content,
-  })
-
-  const prioritized = [
-    ...relatedPosts.filter((p) => p.categorySlug === frontmatter.categorySlug),
-    ...relatedPosts.filter((p) => p.categorySlug !== frontmatter.categorySlug),
-  ]
-
   return (
     <BlogPostLayout
       slug={slug}
@@ -194,16 +166,9 @@ export default async function BlogPostPage({ params }: PageProps) {
       image={frontmatter.image}
       openGraph={frontmatter.openGraph}
       canonical={frontmatter.canonical}
-      relatedPosts={prioritized.slice(0, 3)}
-      toc={toc}
       howTo={frontmatter.howTo}
-      keyTakeaways={keyTakeaways}
-      prismImpact={prismImpact ?? undefined}
     >
       {content}
-      <div className="mt-16">
-        <BlogEmailSignup />
-      </div>
     </BlogPostLayout>
   )
 }

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -1,12 +1,5 @@
-import { Inter } from "next/font/google"
 import type React from "react"
 
-const inter = Inter({
-  subsets: ["latin"],
-  display: "swap",
-})
-
 export default function BlogLayout({ children }: { children: React.ReactNode }) {
-  return <div className={`blog-reading-surface ${inter.className}`}>{children}</div>
+  return <div className="blog-reading-surface">{children}</div>
 }
-

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,158 +1,192 @@
-import type { Metadata } from "next"
-import { notFound } from "next/navigation"
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
 
-import BlogEmailSignup from "@/components/blog-email-signup"
-import BlogFilterNavigationServer from "@/components/blog-filter-navigation-server"
-import Breadcrumbs from "@/components/breadcrumbs"
-import AsciiHeroCard from "@/components/ascii/AsciiHeroCard"
-import Footer from "@/components/footer"
-import Navbar from "@/components/navbar"
-import { CollectionPageSchema, ItemListSchema } from "@/components/schema-markup"
-import SeoTextSection from "@/components/seo-text-section"
-import SimpleBlogGrid from "@/components/simple-blog-grid"
-import SimpleBlogPostCard from "@/components/simple-blog-post-card"
-import { getAllPosts } from "@/lib/mdx-data"
+import BlogFilterNavigationServer from '@/components/blog-filter-navigation-server'
+import Navbar from '@/components/navbar'
+import { CollectionPageSchema, ItemListSchema } from '@/components/schema-markup'
+import { getAllPosts } from '@/lib/mdx-data'
 import {
   getBlogFilterFromCategory,
   normalizeBlogFilter,
-} from "@/lib/blog-topic-filters"
-import BlogCTAButtonLazy from "./BlogCTAButtonLazy"
-import { buildRouteMetadata } from "@/lib/seo/metadata"
-import { firstSearchParamString, type SearchParamValue } from "@/lib/search-params"
+} from '@/lib/blog-topic-filters'
+import { buildRouteMetadata } from '@/lib/seo/metadata'
+import { firstSearchParamString, type SearchParamValue } from '@/lib/search-params'
 
 export const metadata: Metadata = buildRouteMetadata({
   titleStem: 'Growth insights',
-  description: 'Practical lessons on websites, search, AI, ads, and local growth from real Prism work.',
-  path: "/blog",
-  ogImage: "/prism-opengraph.png",
+  description:
+    'Practical lessons on websites, search, AI, ads, and local growth from real Prism work.',
+  path: '/blog',
+  ogImage: '/prism-opengraph.png',
 })
+
+const POSTS_PER_PAGE = 12
+
+function formatDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(date)
+}
+
+function buildPageUrl({
+  category,
+  query,
+  page,
+}: {
+  category: string
+  query: string
+  page: number
+}) {
+  const params = new URLSearchParams()
+  if (category !== 'all') params.set('category', category)
+  if (query.trim()) params.set('q', query.trim())
+  if (page > 1) params.set('page', String(page))
+  const search = params.toString()
+  return search ? `/blog?${search}` : '/blog'
+}
 
 export default async function Blog({
   searchParams,
 }: {
-  searchParams: Promise<{ category?: SearchParamValue; q?: SearchParamValue }>
+  searchParams: Promise<{
+    category?: SearchParamValue
+    q?: SearchParamValue
+    page?: SearchParamValue
+  }>
 }) {
   const resolvedSearchParams = await searchParams
-  const rawCategory = firstSearchParamString(resolvedSearchParams?.category, "all")
+  const rawCategory = firstSearchParamString(resolvedSearchParams?.category, 'all')
   const searchQuery = firstSearchParamString(resolvedSearchParams?.q)
+  const requestedPage = Number.parseInt(
+    firstSearchParamString(resolvedSearchParams?.page, '1'),
+    10,
+  )
 
   const posts = await getAllPosts()
   if (!posts) notFound()
-  const postsWithTopic = posts.map((post) => ({
-    ...post,
-    topic: getBlogFilterFromCategory(post.category),
-  }))
 
   const selectedCategory = normalizeBlogFilter(rawCategory.trim().toLowerCase())
-
   const normalizedQuery = searchQuery.trim().toLowerCase()
-  const filteredPosts = postsWithTopic.filter((post) => {
-    if (selectedCategory !== "all" && post.topic !== selectedCategory) return false
-    if (!normalizedQuery) return true
+  const filteredPosts = posts
+    .map((post) => ({
+      ...post,
+      topic: getBlogFilterFromCategory(post.category),
+    }))
+    .filter((post) => {
+      if (selectedCategory !== 'all' && post.topic !== selectedCategory) return false
+      if (!normalizedQuery) return true
+      return (
+        post.title.toLowerCase().includes(normalizedQuery) ||
+        post.description.toLowerCase().includes(normalizedQuery) ||
+        post.category.toLowerCase().includes(normalizedQuery)
+      )
+    })
 
-    return (
-      post.title.toLowerCase().includes(normalizedQuery) ||
-      post.description.toLowerCase().includes(normalizedQuery) ||
-      post.category.toLowerCase().includes(normalizedQuery)
-    )
-  })
-
+  const totalPages = Math.max(1, Math.ceil(filteredPosts.length / POSTS_PER_PAGE))
+  const currentPage = Number.isFinite(requestedPage)
+    ? Math.min(Math.max(requestedPage, 1), totalPages)
+    : 1
+  const visiblePosts = filteredPosts.slice(
+    (currentPage - 1) * POSTS_PER_PAGE,
+    currentPage * POSTS_PER_PAGE,
+  )
   const blogItems = posts.slice(0, 10).map((post) => ({
     name: post.title,
     description: post.description,
     url: `https://www.design-prism.com/blog/${post.slug}`,
-    itemType: "BlogPosting",
+    itemType: 'BlogPosting',
   }))
 
   return (
-    <div className="blog-reading-surface flex min-h-screen flex-col">
+    <div className="min-h-screen bg-background text-foreground">
       <Navbar />
-      <main className="relative flex-1" id="main-content" tabIndex={-1}>
-        <div className="container mx-auto px-4 md:px-6">
-          <Breadcrumbs items={[{ name: "home", url: "/" }, { name: "blog", url: "/blog" }]} />
-        </div>
-
-        <section className="px-4 py-10 md:py-14">
-          <div className="container mx-auto px-4 md:px-6">
-            <AsciiHeroCard
-              animationName="hands"
-              frameCount={152}
-              fps={18}
-              eyebrow="prism blog"
-              title="Insights & ideas"
-              description="Thoughtful breakdowns on design, development, and digital strategy from the Prism team."
-              ariaLabel="Hands ASCII animation behind the Blog page hero"
-              className="blog-reading-surface"
-              renderMode="canvas"
-            />
-          </div>
-        </section>
-
-        <BlogFilterNavigationServer selectedCategory={selectedCategory} query={searchQuery} />
-
-        <section className="py-8 md:py-12">
-          <div className="container mx-auto px-4 md:px-6">
-            {filteredPosts.length > 0 ? (
-              <SimpleBlogGrid>
-                {filteredPosts.map((post, index) => (
-                    <SimpleBlogPostCard
-                      key={post.slug}
-                      title={post.title}
-                      category={post.category}
-                      date={post.date}
-                      author={post.author}
-                      description={post.description}
-                      slug={post.slug}
-                      image={post.image}
-                      gradientClass={post.gradientClass}
-                      prefetch={false}
-                      priority={index === 0}
-                  />
-                ))}
-              </SimpleBlogGrid>
-            ) : (
-              <div className="rounded-md border border-dashed border-border/60 bg-card/20 py-16 text-center">
-                <h3 className="mb-2 text-xl font-semibold text-foreground">no posts found</h3>
-                <p className="text-muted-foreground">try adjusting your filters or search query</p>
-              </div>
-            )}
-          </div>
-        </section>
-
-        <BlogEmailSignup />
-
-        <section className="border-t border-border/60 bg-card/15 py-12 md:py-16">
-          <div className="container mx-auto px-4 md:px-6">
-            <div className="mx-auto max-w-2xl space-y-4 text-center">
-              <h2 className="text-2xl font-semibold sm:text-3xl">Want to work with us?</h2>
-              <p className="text-muted-foreground">Let's discuss how we can help your business grow.</p>
-              <div className="pt-4">
-                <BlogCTAButtonLazy />
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <SeoTextSection title="Prism blog: design, development, and growth">
-          <p>
-            We publish practical notes on product design, engineering, and modern SEO: how to ship faster,
-            write clearer interfaces, and measure what matters. Each post is written from real client work
-            and experiments, not theory.
+      <main id="main-content" tabIndex={-1}>
+        <section className="mx-auto max-w-4xl px-5 pb-10 pt-12 sm:px-8 sm:pb-14 sm:pt-20">
+          <p className="font-mono text-[11px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+            Prism blog
           </p>
-        </SeoTextSection>
+          <h1 className="blog-display-title mt-4 text-balance">Ideas worth building on.</h1>
+          <p className="blog-hero-subtitle mt-5 text-muted-foreground">
+            Clear thinking on design, technology, and growth, drawn from the work.
+          </p>
+        </section>
+
+        <BlogFilterNavigationServer
+          selectedCategory={selectedCategory}
+          query={searchQuery}
+          className="mx-auto max-w-4xl"
+        />
+
+        <section className="mx-auto max-w-4xl px-5 pb-24 sm:px-8 sm:pb-32">
+          {visiblePosts.length > 0 ? (
+            <div className="border-t border-border/70">
+              {visiblePosts.map((post) => (
+                <article key={post.slug} className="border-b border-border/70 py-7 sm:py-9">
+                  <Link
+                    href={`/blog/${post.slug}`}
+                    prefetch={false}
+                    className="group block rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4 focus-visible:ring-offset-background"
+                  >
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground sm:text-[11px]">
+                      <span>{post.category}</span>
+                      <span aria-hidden>·</span>
+                      <time dateTime={new Date(post.date).toISOString()}>{formatDate(post.date)}</time>
+                    </div>
+                    <h2 className="mt-3 max-w-[28ch] text-balance text-[1.45rem] font-semibold leading-[1.18] tracking-[-0.025em] transition-colors group-hover:text-muted-foreground sm:text-[1.8rem]">
+                      {post.title}
+                    </h2>
+                    <p className="mt-3 max-w-[68ch] text-[0.98rem] leading-7 text-muted-foreground sm:text-base">
+                      {post.description}
+                    </p>
+                  </Link>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className="border-y border-border/70 py-16">
+              <h2 className="text-xl font-semibold">No writing found.</h2>
+              <p className="mt-2 text-muted-foreground">Try another topic or search.</p>
+            </div>
+          )}
+
+          {totalPages > 1 ? (
+            <nav className="mt-10 flex items-center justify-between" aria-label="Blog pages">
+              {currentPage > 1 ? (
+                <Link
+                  href={buildPageUrl({ category: selectedCategory, query: searchQuery, page: currentPage - 1 })}
+                  className="inline-flex min-h-11 items-center text-sm text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground"
+                >
+                  ← Newer
+                </Link>
+              ) : <span />}
+              <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                {currentPage} / {totalPages}
+              </span>
+              {currentPage < totalPages ? (
+                <Link
+                  href={buildPageUrl({ category: selectedCategory, query: searchQuery, page: currentPage + 1 })}
+                  className="inline-flex min-h-11 items-center text-sm text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground"
+                >
+                  Older →
+                </Link>
+              ) : <span />}
+            </nav>
+          ) : null}
+        </section>
+
         <CollectionPageSchema
           name="Prism Blog"
           description="Insights on web design, AI marketing, and growth systems for local businesses."
           url="https://www.design-prism.com/blog"
           isPartOfId="https://www.design-prism.com/#website"
         />
-        <ItemListSchema
-          name="Latest Prism blog posts"
-          url="https://www.design-prism.com/blog"
-          items={blogItems}
-        />
+        <ItemListSchema name="Latest Prism blog posts" url="https://www.design-prism.com/blog" items={blogItems} />
       </main>
-      <Footer />
     </div>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1915,13 +1915,7 @@ select {
 
 /* Blog Typography Improvements */
 .blog-reading-surface {
-  font-family:
-    Inter,
-    var(--font-sans),
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    sans-serif;
+  font-family: var(--font-sans), -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -1942,15 +1936,15 @@ select {
 }
 
 .blog-reading-surface .blog-post-title {
-  font-size: clamp(1.9rem, 3.3vw, 2.6rem);
-  line-height: 1.1;
+  font-size: clamp(2.2rem, 5vw, 3.75rem);
+  line-height: 1.04;
   font-weight: 650;
   letter-spacing: -0.02em;
 }
 
 .blog-reading-surface .blog-post-lead {
-  font-size: clamp(1rem, 0.96rem + 0.16vw, 1.12rem);
-  line-height: 1.68;
+  font-size: clamp(1.05rem, 1rem + 0.2vw, 1.2rem);
+  line-height: 1.65;
   color: hsl(var(--muted-foreground));
 }
 
@@ -1968,7 +1962,7 @@ select {
 
 .prose-blog {
   @apply prose prose-neutral dark:prose-invert max-w-none;
-  font-size: clamp(1rem, 0.96rem + 0.18vw, 1.12rem);
+  font-size: clamp(1.0625rem, 1.01rem + 0.2vw, 1.125rem);
   line-height: 1.78;
   letter-spacing: 0.003em;
   color: rgb(20 20 20);
@@ -2179,13 +2173,13 @@ select {
 
 @media (max-width: 640px) {
   .prose-blog {
-    font-size: 1rem;
-    line-height: 1.75;
+    font-size: 1.0625rem;
+    line-height: 1.78;
   }
 
   .prose-blog p {
     margin-bottom: 1.4rem;
-    line-height: 1.78;
+    line-height: 1.82;
   }
 
   .prose-blog h1,

--- a/components/blog-filter-navigation-server.tsx
+++ b/components/blog-filter-navigation-server.tsx
@@ -1,7 +1,4 @@
 import Link from "next/link"
-import { Search, X } from "lucide-react"
-
-import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
   BLOG_FILTER_ITEMS,
@@ -44,18 +41,13 @@ export default function BlogFilterNavigationServer({
   return (
     <div
       className={cn(
-        "sticky top-[var(--prism-header-height,0px)] z-40 border-b border-border/60 bg-background/80 backdrop-blur-md supports-[backdrop-filter]:bg-background/60",
+        "px-5 pb-8 sm:px-8 sm:pb-10",
         className,
       )}
     >
-      <div className="container mx-auto px-4 py-3 md:py-4">
-        <div className="space-y-3">
-          <form action="/blog" method="get" className="relative max-w-2xl">
-            <Search
-              className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-              aria-hidden="true"
-              focusable="false"
-            />
+      <div className="border-t border-border/70 pt-6">
+        <div className="space-y-5">
+          <form action="/blog" method="get" className="flex max-w-xl items-center gap-3">
             {normalizedSelected !== "all" ? (
               <input type="hidden" name="category" value={normalizedSelected} />
             ) : null}
@@ -63,32 +55,27 @@ export default function BlogFilterNavigationServer({
               type="search"
               name="q"
               defaultValue={normalizedQuery}
-              placeholder="Search posts…"
+              placeholder="Search writing"
               aria-label="Search posts"
               autoComplete="off"
-              className="h-auto w-full rounded-md border border-border/60 bg-card/30 py-3 pl-10 pr-10 text-base leading-6 transition-colors duration-200 focus:bg-card focus-visible:ring-ring"
+              className="h-11 w-full rounded-none border-x-0 border-t-0 border-border/70 bg-transparent px-0 text-base shadow-none focus-visible:border-foreground focus-visible:ring-0"
             />
             <button type="submit" className="sr-only">
               Search
             </button>
             {normalizedQuery ? (
-              <Button
-                asChild
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="absolute right-2 top-1/2 h-7 w-7 -translate-y-1/2 rounded-md hover:bg-muted/60"
-                aria-label="Clear search"
+              <Link
+                href={buildBlogUrl({ category: normalizedSelected, query: "" })}
+                prefetch={false}
+                className="inline-flex min-h-11 shrink-0 items-center font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground hover:text-foreground"
               >
-                <Link href={buildBlogUrl({ category: normalizedSelected, query: "" })} prefetch={false}>
-                  <X className="h-3 w-3 text-muted-foreground" aria-hidden="true" focusable="false" />
-                </Link>
-              </Button>
+                Clear
+              </Link>
             ) : null}
           </form>
 
-          <div className="w-full overflow-x-auto scrollbar-hide pb-1">
-            <div className="flex w-max min-w-full flex-nowrap items-center justify-start gap-2">
+          <div className="w-full overflow-x-auto scrollbar-hide">
+            <div className="flex w-max min-w-full flex-nowrap items-center justify-start gap-5">
               {BLOG_FILTER_ITEMS.map((category) => {
                 const slug = category.slug.toLowerCase()
                 const isActive = slug === normalizedSelected
@@ -99,18 +86,11 @@ export default function BlogFilterNavigationServer({
                     href={buildBlogUrl({ category: slug, query: normalizedQuery })}
                     prefetch={false}
                     className={cn(
-                      "shrink-0 inline-flex items-center gap-2 rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-xs font-semibold tracking-[0.12em] text-muted-foreground transition-colors duration-200 hover:bg-muted/60 hover:text-foreground",
-                      isActive && "border-primary bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground",
+                      "inline-flex min-h-11 shrink-0 items-center border-b border-transparent font-mono text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground transition-colors hover:text-foreground",
+                      isActive && "border-foreground text-foreground",
                     )}
                     aria-current={isActive ? "true" : undefined}
                   >
-                    {category.icon ? (
-                      <category.icon
-                        className={cn("h-3.5 w-3.5 shrink-0", isActive ? "text-primary-foreground" : "text-muted-foreground")}
-                        aria-hidden="true"
-                        focusable="false"
-                      />
-                    ) : null}
                     {category.label}
                   </Link>
                 )

--- a/components/blog-post-layout.tsx
+++ b/components/blog-post-layout.tsx
@@ -1,23 +1,8 @@
 import { BlogPostErrorBoundary } from '@/components/blog-error-boundary'
-import BlogHeroMedia from '@/components/blog/BlogHeroMedia'
 import BlogScrollProgress from '@/components/blog/BlogScrollProgress'
-import BlogConversionCta from '@/components/blog/BlogConversionCta'
-import CopyBlogMarkdownButton from '@/components/blog/copy-blog-markdown-button'
-import GetStartedCTA from '@/components/GetStartedCTA'
-import Footer from '@/components/footer'
 import Navbar from '@/components/navbar'
-import BlogShareIcons from '@/components/blog/blog-share-icons'
-import BlogTableOfContents, {
-  type BlogTocItem,
-} from '@/components/blog/BlogTableOfContents'
 import { BlogPostSchema, HowToSchema } from '@/components/schema-markup'
-import SimpleBlogPostCard from '@/components/simple-blog-post-card'
-import Breadcrumbs from '@/components/breadcrumbs'
-import type { PrismImpactConfig } from '@/lib/prism-blog-impact'
-import { cn } from '@/lib/utils'
 import { toAbsoluteUrl } from '@/lib/url'
-import BlogBackToTopButton from '@/components/blog/blog-back-to-top'
-import BlogPostFeedback from '@/components/blog/blog-post-feedback'
 import Link from 'next/link'
 
 interface Props {
@@ -33,30 +18,13 @@ interface Props {
   readingTimeMinutes?: number
   category: string
   image?: string
-  keyTakeaways?: string[]
   openGraph?: {
-    type?: string
-    title?: string
-    description?: string
     url?: string
-    image?: string
-    siteName?: string
     publishedTime?: string
     modifiedTime?: string
     authors?: string[]
   }
   canonical?: string
-  relatedPosts?: Array<{
-    slug: string
-    title: string
-    description: string
-    date: string
-    author: string
-    category: string
-    gradientClass: string
-    image?: string
-  }>
-  toc?: BlogTocItem[]
   howTo?: {
     title: string
     description: string
@@ -65,7 +33,6 @@ interface Props {
     supplies?: string[]
     tools?: string[]
   }
-  prismImpact?: PrismImpactConfig
 }
 
 export default function BlogPostLayout({
@@ -81,336 +48,105 @@ export default function BlogPostLayout({
   readingTimeMinutes,
   category,
   image,
-  keyTakeaways = [],
   openGraph,
   canonical,
-  relatedPosts = [],
-  toc = [],
   howTo,
-  prismImpact,
 }: Props) {
   const effectiveImageUrl = image
     ? toAbsoluteUrl(image)
     : toAbsoluteUrl('/prism-opengraph.png')
-
-  const shareUrl =
+  const postUrl =
     openGraph?.url || canonical || `https://www.design-prism.com/blog/${slug}`
-  const hasToc = toc.length > 0
-  const activePrismImpact =
-    prismImpact && prismImpact.forceRender !== false ? prismImpact : null
-  const howToSteps = howTo?.steps ?? []
-  const howToSupplies = howTo?.supplies ?? []
-  const howToTools = howTo?.tools ?? []
-
-  const publishedLabel = publishedDate || new Intl.DateTimeFormat(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  }).format(new Date(date))
+  const publishedLabel =
+    publishedDate ||
+    new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    }).format(new Date(date))
   const updatedLabel = updatedDate || undefined
-  const isUpdated = Boolean(updatedLabel && updatedLabel !== publishedLabel)
-  const readingTime =
-    typeof readingTimeMinutes === 'number' && readingTimeMinutes > 0
-      ? `${readingTimeMinutes} min read`
-      : undefined
-
-  const normalizedAuthor = author.trim()
-  const isEnzoAuthor = normalizedAuthor.toLowerCase() === 'enzo sison'
-
-  const isExternalLink = (href: string) => /^https?:\/\//i.test(href)
-
-  const renderPrismLink = (href: string, label: string) => (
-    <a
-      href={href}
-      target={isExternalLink(href) ? '_blank' : undefined}
-      rel={isExternalLink(href) ? 'noopener noreferrer' : undefined}
-      className="font-medium text-foreground underline decoration-neutral-500 underline-offset-3 transition-colors hover:decoration-neutral-700"
-    >
-      {label}
-    </a>
-  )
+  const readingTime = `${Math.max(1, readingTimeMinutes ?? 1)} min read`
+  const isEnzoAuthor = author.trim().toLowerCase() === 'enzo sison'
 
   return (
-    <div className="flex min-h-screen flex-col bg-background text-foreground">
+    <div className="min-h-screen bg-background text-foreground">
       <BlogScrollProgress />
-
       <Navbar />
-      <main className="flex-1" id="main-content" tabIndex={-1}>
-        <div className="w-full py-6 sm:py-8 md:py-10">
-          <div className="container mx-auto px-4 sm:px-6">
-            <div className={cn('mx-auto', hasToc ? 'max-w-6xl' : 'max-w-3xl')}>
-              <div className="max-w-3xl">
-                <Breadcrumbs
-                  items={[
-                    { name: 'home', url: '/' },
-                    { name: 'blog', url: '/blog' },
-                    { name: title, url: shareUrl },
-                  ]}
-                />
-              </div>
-              <article>
-                <header className="relative mb-6 sm:mb-8">
-                  <div className="max-w-3xl">
-                    <BlogHeroMedia title={title} image={image} slug={slug} />
-                    <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-muted-foreground sm:text-sm">
-                      <span className="inline-block rounded-md border border-border/60 bg-muted/30 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/90">
-                        {category}
-                      </span>
-                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                        <time dateTime={new Date(date).toISOString()}>
-                          {publishedLabel}
-                        </time>
-                        {isUpdated ? (
-                          <>
-                            <span className="text-border/70" aria-hidden>
-                              &middot;
-                            </span>
-                            <span>Updated {updatedLabel}</span>
-                          </>
-                        ) : null}
-                        <span className="text-border/70" aria-hidden>
-                          &middot;
-                        </span>
-                        <span>{readingTime || '1 min read'}</span>
-                        <span className="text-border/70" aria-hidden>
-                          &middot;
-                        </span>
-                        <span className="font-medium text-foreground/80 normal-case">
-                          By{" "}
-                          {isEnzoAuthor ? (
-                            <Link
-                              href="/about"
-                              className="underline underline-offset-4 transition-colors hover:text-foreground"
-                            >
-                              {author}
-                            </Link>
-                          ) : (
-                            author
-                          )}
-                        </span>
-                      </div>
-                    </div>
-                    <h1 className="blog-post-title text-balance">
-                      {h1Title || title}
-                    </h1>
-                    <p className="blog-post-lead mt-4 max-w-[70ch]">
-                      {description}
-                    </p>
-                    <div className="mt-5 flex flex-wrap items-center justify-start gap-3">
-                      <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
-                        share this post
-                      </p>
-                      <CopyBlogMarkdownButton slug={slug} />
-                      <BlogShareIcons url={shareUrl} title={title} />
-                    </div>
-                  </div>
-                </header>
 
-                {hasToc ? (
-                  <div className="mt-8 lg:grid lg:grid-cols-[minmax(0,1fr)_260px] lg:gap-10">
-                    <aside className="order-1 lg:order-2 lg:mt-0">
-                      <BlogTableOfContents items={toc} />
-                    </aside>
-                    <div className="order-2 lg:order-1 min-w-0">
-                      <div className="max-w-3xl">
-                        <BlogPostErrorBoundary>
-                          <div className="prose-blog">{children}</div>
-                        </BlogPostErrorBoundary>
-                      </div>
-                    </div>
-                  </div>
+      <main id="main-content" tabIndex={-1}>
+        <article className="mx-auto w-full max-w-[46rem] px-5 pb-20 pt-10 sm:px-8 sm:pb-28 sm:pt-16">
+          <header className="mb-12 border-b border-border/60 pb-10 sm:mb-16 sm:pb-14">
+            <Link
+              href="/blog"
+              className="inline-flex min-h-11 items-center font-mono text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              ← All writing
+            </Link>
+
+            <p className="mt-8 font-mono text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground sm:mt-10">
+              {category}
+            </p>
+            <h1 className="blog-post-title mt-4 text-balance">
+              {h1Title || title}
+            </h1>
+            <p className="blog-post-lead mt-5">{description}</p>
+
+            <div className="mt-7 flex flex-wrap gap-x-2 gap-y-1 font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
+              <span>
+                By{' '}
+                {isEnzoAuthor ? (
+                  <Link href="/about" className="underline underline-offset-4 hover:text-foreground">
+                    {author}
+                  </Link>
                 ) : (
-                  <div className="max-w-3xl">
-                    <BlogPostErrorBoundary>
-                      <div className="prose-blog">{children}</div>
-                    </BlogPostErrorBoundary>
-                  </div>
+                  author
                 )}
-
-                {keyTakeaways.length > 0 ? (
-                  <section className="mt-12 rounded-2xl border border-border/60 bg-card/40 p-6 sm:p-8">
-                    <h2 className="text-2xl font-bold tracking-tight">Key takeaways</h2>
-                    <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
-                      {keyTakeaways.map((takeaway) => (
-                        <li key={takeaway}>
-                          {takeaway}
-                        </li>
-                      ))}
-                    </ul>
-                  </section>
-                ) : null}
-
-                <BlogPostFeedback slug={slug} />
-
-                <BlogConversionCta slug={slug} />
-
-                {activePrismImpact ? (
-                  <section className="mt-16 rounded-2xl border border-border/60 bg-card/40 p-6 sm:p-8">
-                    <div className="mb-6">
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                        Productized execution
-                      </p>
-                      <h2 className="mt-2 text-2xl font-bold tracking-tight">
-                        How this translates at Prism
-                      </h2>
-                      <p className="mt-3 max-w-[70ch] text-sm text-muted-foreground">
-                        {activePrismImpact.impactSummary}
-                      </p>
-                    </div>
-
-                    <div className="mt-6">
-                      <h3 className="text-lg font-semibold">What this improves</h3>
-                      <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
-                        {activePrismImpact.clientOutcomes.map((outcome) => (
-                          <li key={outcome}>{outcome}</li>
-                        ))}
-                      </ul>
-                    </div>
-
-                    <div className="mt-8">
-                      <h3 className="text-lg font-semibold">How we apply this at Prism</h3>
-                      <ul className="mt-3 space-y-2 text-sm">
-                        {activePrismImpact.serviceLinks.map((link) => (
-                          <li
-                            key={`${link.label}-${link.href}`}
-                            className="list-none"
-                          >
-                            <div className="flex flex-wrap gap-2">
-                              {renderPrismLink(link.href, link.label)}
-                              <span className="text-muted-foreground">{link.reason}</span>
-                            </div>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-
-                    <div className="mt-8">
-                      <h3 className="text-lg font-semibold">
-                        Further reading / sources
-                      </h3>
-                      <ul className="mt-3 space-y-2 text-sm">
-                        {activePrismImpact.referenceLinks.map((link) => (
-                          <li
-                            key={`${link.label}-${link.href}`}
-                            className="list-none"
-                          >
-                            <div className="flex flex-wrap gap-2">
-                              {renderPrismLink(link.href, link.label)}
-                              <span className="text-muted-foreground">{link.reason}</span>
-                            </div>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  </section>
-                ) : null}
-
-                {relatedPosts.length > 0 && (
-                  <section className="mt-16 rounded-2xl border border-border/60 bg-card/40 p-6 sm:p-8">
-                    <div className="flex flex-col gap-2 mb-6">
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                        Keep learning
-                      </p>
-                      <h2 className="text-2xl font-bold tracking-tight">
-                        Related posts
-                      </h2>
-                      <p className="text-sm text-muted-foreground">
-                        More experiments and playbooks from the Prism team.
-                      </p>
-                    </div>
-                    <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-                      {relatedPosts.map((related) => (
-                        <SimpleBlogPostCard
-                          key={related.slug}
-                          title={related.title}
-                          category={related.category}
-                          date={related.date}
-                          author={related.author}
-                          description={related.description}
-                          slug={related.slug}
-                          image={related.image}
-                          gradientClass={related.gradientClass}
-                          compact
-                        />
-                      ))}
-                    </div>
-                  </section>
-                )}
-                {/* Contextual CTA */}
-                <div className="mt-12">
-                  <GetStartedCTA
-                    heading={(() => {
-                      const c = (category || '').toLowerCase()
-                      if (c.includes('ai') && c.includes('growth'))
-                        return 'ready to be agent‑ready?'
-                      if (c.includes('ai') && c.includes('marketing'))
-                        return 'turn ai exposure into booked revenue'
-                      if (c.includes('seo') || c.includes('search'))
-                        return 'recover organic traffic and convert it into leads'
-                      if (
-                        c.includes('design') ||
-                        c.includes('product') ||
-                        c.includes('development')
-                      )
-                        return 'ship a conversion‑focused site that moves metrics'
-                      if (c.includes('entrepreneur'))
-                        return 'get a focused plan and ship in days, not months'
-                      return 'want help executing this playbook?'
-                    })()}
-                    description={(() => {
-                      const c = (category || '').toLowerCase()
-                      if (c.includes('ai') && c.includes('growth'))
-                        return 'we’ll stand up your agent brief, wire the actions map, and ship your first 3 experiments in 30 days.'
-                      if (c.includes('ai') && c.includes('marketing'))
-                        return 'we help you build the context moat, get agent‑discoverable, and instrument bookings end‑to‑end.'
-                      if (c.includes('seo') || c.includes('search'))
-                        return 'ai has compressed clicks. Let’s rebuild your funnel with task‑first pages, rich context, and interactive wins.'
-                      if (
-                        c.includes('design') ||
-                        c.includes('product') ||
-                        c.includes('development')
-                      )
-                        return 'from strategy to shipped ui: fast pages, clear messaging, and measured outcomes.'
-                      if (c.includes('business'))
-                        return 'we’ll help you choose one focus bet, design the experiments, and measure what matters.'
-                      return 'work with prism to apply these steps to your brand: fast, focused, and measured.'
-                    })()}
-                    analyticsLabel={`blog_post_${slug}`}
-                    variant="gradient"
-                    className="border-t border-border/60"
-                  />
-                </div>
-                <BlogBackToTopButton />
-              </article>
+              </span>
+              <span aria-hidden>·</span>
+              <time dateTime={new Date(date).toISOString()}>{publishedLabel}</time>
+              {updatedLabel && updatedLabel !== publishedLabel ? (
+                <>
+                  <span aria-hidden>·</span>
+                  <span>Updated {updatedLabel}</span>
+                </>
+              ) : null}
+              <span aria-hidden>·</span>
+              <span>{readingTime}</span>
             </div>
-          </div>
-        </div>
+          </header>
+
+          <BlogPostErrorBoundary>
+            <div className="prose-blog">{children}</div>
+          </BlogPostErrorBoundary>
+
+          <footer className="mt-16 border-t border-border/60 pt-8 sm:mt-24">
+            <Link
+              href="/blog"
+              className="inline-flex min-h-11 items-center text-sm font-medium text-muted-foreground underline decoration-border underline-offset-4 transition-colors hover:text-foreground"
+            >
+              Read more from Prism
+            </Link>
+          </footer>
+        </article>
       </main>
-      <Footer />
+
       <BlogPostSchema
         title={title}
         description={description}
-        url={
-          openGraph?.url ||
-          canonical ||
-          `https://www.design-prism.com/blog/${slug}`
-        }
+        url={postUrl}
         imageUrl={effectiveImageUrl}
         datePublished={openGraph?.publishedTime || date}
         dateModified={openGraph?.modifiedTime || date}
-        authorName={author || openGraph?.authors?.[0] || 'prism'}
+        authorName={author || openGraph?.authors?.[0] || 'Prism'}
       />
       {howTo ? (
         <HowToSchema
           name={howTo.title}
           description={howTo.description}
           totalTime={howTo.totalTime}
-          supplies={howToSupplies}
-          tools={howToTools}
-          steps={howToSteps.map((step) => ({
-            name: step.title,
-            text: step.text,
-          }))}
+          supplies={howTo.supplies ?? []}
+          tools={howTo.tools ?? []}
+          steps={howTo.steps.map((step) => ({ name: step.title, text: step.text }))}
         />
       ) : null}
     </div>

--- a/docs/blog-content-architecture.md
+++ b/docs/blog-content-architecture.md
@@ -221,7 +221,7 @@ If you rebrand or change domains, update the `CANONICAL_HOST` constant to keep f
 2. Populate required frontmatter fields.
 3. Write content in Markdown/MDX. Avoid inline styling—`prose-blog` handles typography.
 4. For embeds and interactive widgets, only use MDX components that are registered in `lib/mdx.tsx` / `components/mdx-components.tsx`. Use globally available names like `<YouTubeVideoEmbed />`, `<VideoObjectSchema />`, and `<VideoPlayer />` instead of assuming a post-local import alone will work at runtime.
-5. The layout renders the post title as the single H1. Use H2 for major sections and H3 for sub-sections so the table of contents stays accurate.
+5. The layout renders the post title as the single H1. Use H2 for major sections and H3 for sub-sections to keep the article hierarchy clear.
 6. Decide search visibility:
    - Default/no action: the post remains live by direct URL but noindex and excluded from blog index/RSS/latest-post/sitemap surfaces.
    - Search-visible: add the slug to `INDEXABLE_BLOG_SLUGS` in `lib/seo/search-visibility.ts` only when it supports dental or local-growth authority.

--- a/docs/blog-styling-guide.md
+++ b/docs/blog-styling-guide.md
@@ -99,10 +99,12 @@ This is an informational callout box.
 
 The blog styling system consists of:
 
-1. **`app/blog/layout.tsx`**: Applies Inter only within the blog route segment
+1. **`app/blog/layout.tsx`**: Keeps blog pages on Prism's shared Geist type system
 2. **`blog-reading-surface` + `prose-blog` classes**: Route-scoped typography tuning for long-form reading
-3. **MDX renderer**: Cleans up inline styles automatically
-4. **Dark mode**: Automatic color adjustments for dark theme
+3. **Text-first page chrome**: Article pages omit hero media, sharing controls, table-of-contents panels, promotional modules, related-card grids, and the global footer so the writing stays primary
+4. **Compact index**: The blog index uses a paginated text list instead of image cards, with search and topic filters kept visually quiet
+5. **MDX renderer**: Cleans up inline styles automatically
+6. **Dark mode**: Automatic color adjustments for dark theme
 
 ## Migration from Old Posts
 


### PR DESCRIPTION
## Summary
- replace the image-heavy blog grid with a compact, paginated text list
- reduce article pages to a single reading column with essential metadata only
- remove hero media, share tools, TOC, signup, feedback, conversion, related-post, and global-footer UI from articles
- increase mobile article type to 17px with a 1.78 line height
- document the text-first blog system

## Validation
- full ESLint run: 0 errors (77 existing warnings)
- TypeScript: passed
- Jest: 84 suites / 372 tests passed
- Next.js production build: passed
- responsive browser QA at 390x844 and 1440x1000
- search, category filters, and pagination verified
- no horizontal overflow at either viewport